### PR TITLE
Support CPython 3.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
         run: black --check .
       - name: lint
         run: |
-          ruff .
+          ruff check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,13 +6,13 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.13.0rc.2" ]
+        python-version: [ "3.13.0rc.3" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.13.0rc.1" ]
+        python-version: [ "3.13.0rc.2" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.13.0rc.3" ]
+        python-version: [ "3.13.0" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "nogil-3.9" ]
+        python-version: [ "3.13.0" ]
     permissions:
       id-token: write  # necessary for OIDC publishing https://docs.pypi.org/trusted-publishers/adding-a-publisher/
 
@@ -20,16 +20,11 @@ jobs:
         uses: dpdani/setup-python@nogil
         with:
           python-version: ${{ matrix.python-version }}
-      - name: check nogil
-        run: |
-          python -c "import sys; print(sys.flags.nogil);"
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
       - name: build package
         run: python -m build
-      - name: remove wheels  # cannot yet publish wheels for free-threaded python
-        run: rm dist/*.whl
       - name: publish package
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,14 +5,14 @@ on:
     types: [ published ]
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: [ "3.13.0" ]
     permissions:
-      id-token: write  # necessary for OIDC publishing https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+      id-token: write  # OIDC publishing https://docs.pypi.org/trusted-publishers/adding-a-publisher/
 
     steps:
       - uses: actions/checkout@v3
@@ -26,5 +26,7 @@ jobs:
           pip install .[dev]
       - name: build package
         run: python -m build
+      - name: remove wheels  # TODO
+        run: rm dist/*.whl
       - name: publish package
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.13.0rc.3",
+          "3.13.0",
           "3.13-dev",
         ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
           - macos-13
           - macos-14
         python-version:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.13.0rc.2",
+          "3.13.0rc.3",
           "3.13-dev",
         ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - 3.13.0
           - 3.13t
 
-    name: test / ${{ matrix.os }} / ${{ matrix.python-version }}
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,15 +27,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: set up python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v3
+        uses: deadsnakes/action@v3.2.0
         if: endsWith(matrix.python-version, 't')
-      - if: endsWith(matrix.python-version, 't')
-        run: |
-          uv python install ${{ matrix.python-version }}
-          uv venv --python ${{ matrix.python-version }}
-          . .venv/bin/activate
-          echo PATH=$PATH >> $GITHUB_ENV
-          uv pip install pip
+        with:
+          python-version: 3.13
+          nogil: true
+#      - if: endsWith(matrix.python-version, 't')
+#        run: |
+#          uv python install ${{ matrix.python-version }}
+#          uv venv --python ${{ matrix.python-version }}
+#          . .venv/bin/activate
+#          echo PATH=$PATH >> $GITHUB_ENV
+#          uv pip install pip
       - run: python --version --version && which python
       - name: system info
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: set up python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v3
         if: endsWith(matrix.python-version, 't')
-      - run: |
+        run: |
           uv python install ${{ matrix.python-version }}
           uv venv --python ${{ matrix.python-version }}
           . .venv/bin/activate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: [
           "3.13.0",
-          "3.13-dev",
+          "3.13t",
         ]
 
     name: ${{ matrix.python-version }}
@@ -23,15 +23,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
-        if: "!endsWith(matrix.python-version, '-dev')"
+        if: "!endsWith(matrix.python-version, 't')"
         with:
           python-version: ${{ matrix.python-version }}
       - name: set up python ${{ matrix.python-version }}
-        uses: deadsnakes/action@v3.1.0
-        if: endsWith(matrix.python-version, '-dev')
-        with:
-          python-version: ${{ matrix.python-version }}
-          nogil: true
+        uses: astral-sh/setup-uv@v3
+        if: endsWith(matrix.python-version, 't')
+      - run: |
+          uv python install ${{ matrix.python-version }}
+          uv venv --python ${{ matrix.python-version }}
+          . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
       - run: python --version --version && which python
       - name: system info
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -16,6 +16,8 @@ jobs:
           "3.13.0rc.3",
           "3.13-dev",
         ]
+
+    name: test ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
       - name: set up python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v3
         if: endsWith(matrix.python-version, 't')
+      - if: endsWith(matrix.python-version, 't')
         run: |
           uv python install ${{ matrix.python-version }}
           uv venv --python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           "3.13-dev",
         ]
 
-    name: test ${{ matrix.python-version }}
+    name: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
           uv venv --python ${{ matrix.python-version }}
           . .venv/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
+          uv pip install pip
       - run: python --version --version && which python
       - name: system info
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.13.0rc.1",
+          "3.13.0rc.2",
           "3.13-dev",
         ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,11 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13
-          - macos-14
         python-version:
           - 3.13.0
           - 3.13t
 
-    name: test on ${{ matrix.os }} ${{ matrix.python-version }}
+    name: test / ${{ matrix.os }} / ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -51,12 +49,9 @@ jobs:
       - name: test with pytest
         run: |
           pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml
-        if: ${{ always() }}
       - name: upload pytest test results
         uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
         if: ${{ always() }}
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
           pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml
         if: ${{ always() }}
       - name: upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,18 +27,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: set up python ${{ matrix.python-version }}
-        uses: deadsnakes/action@v3.2.0
+        uses: astral-sh/setup-uv@v3
         if: endsWith(matrix.python-version, 't')
-        with:
-          python-version: 3.13
-          nogil: true
-#      - if: endsWith(matrix.python-version, 't')
-#        run: |
-#          uv python install ${{ matrix.python-version }}
-#          uv venv --python ${{ matrix.python-version }}
-#          . .venv/bin/activate
-#          echo PATH=$PATH >> $GITHUB_ENV
-#          uv pip install pip
+      - if: endsWith(matrix.python-version, 't')
+        run: |
+          uv python install ${{ matrix.python-version }}
+          uv venv --python ${{ matrix.python-version }}
+          . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
+          uv pip install pip
       - run: python --version --version && which python
       - name: system info
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,17 +7,20 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [
-          "3.13.0",
-          "3.13t",
-        ]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-13
+          - macos-14
+        python-version:
+          - 3.13.0
+          - 3.13t
 
-    name: ${{ matrix.python-version }}
+    name: test on ${{ matrix.os }} ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -56,3 +59,5 @@ jobs:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
         if: ${{ always() }}
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cereggii
 
+![supports free-threading](https://github.com/dpdani/free-threading-badges/raw/main/supported.svg)
+
 Thread synchronization utilities for free-threaded Python.
 
 This library provides some atomic data types which, in a multithreaded context, are generally more performant compared

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cereggii
 
-![supports free-threading](https://github.com/dpdani/free-threading-badges/raw/main/supported.svg)
+[![supports free-threading](https://github.com/dpdani/free-threading-badges/raw/main/supported.svg)](https://py-free-threading.github.io/)
 
 Thread synchronization utilities for free-threaded Python.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,12 @@ install_components = ["python_modules"]
 
 
 [tool.black]
-target-version = ["py39"]
+target-version = ["py312"]  # no support for 3.13 yet
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"  # no support for 3.13 yet
 line-length = 120
 select = [
   "A",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["py-build-cmake"]
+requires = ["py-build-cmake~=0.1.8"]
 build-backend = "py_build_cmake.build"
 
 
@@ -55,19 +55,6 @@ source_path = "src"
 args = ["-L"]
 build_args = ["-j"]
 install_components = ["python_modules"]
-
-
-[tool.cibuildwheel]
-build-frontend = "build"
-free-threaded-support = true
-test-requires = ".[dev]"
-test-command = "pytest {project}"
-
-[tool.cibuildwheel.linux]
-archs = ["x86_64"]
-
-[tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
 
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["py-build-cmake~=0.1.8"]
+requires = ["py-build-cmake"]
 build-backend = "py_build_cmake.build"
 
 
@@ -50,7 +50,7 @@ include = ["CMakeLists.txt", "src/CMakeLists.txt", "src/include/*"]
 
 [tool.py-build-cmake.cmake]
 minimum_version = "3.18"
-build_type = "Debug"
+build_type = "RelWithDebInfo"
 source_path = "src"
 args = ["-L"]
 build_args = ["-j"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py312"  # no support for 3.13 yet
 line-length = 120
+
+[lint]
 select = [
   "A",
   "ARG",
@@ -112,11 +114,9 @@ unfixable = [
   # Don't touch unused imports
   "F401",
 ]
-
-[tool.ruff.isort]
 known-first-party = ["cereggii"]
 
-[tool.ruff.per-file-ignores]
+[lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ include = ["CMakeLists.txt", "src/CMakeLists.txt", "src/include/*"]
 
 [tool.py-build-cmake.cmake]
 minimum_version = "3.18"
-build_type = "RelWithDebInfo"
+build_type = "Debug"
 source_path = "src"
 args = ["-L"]
 build_args = ["-j"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-  "build==1.0.3",
-  "pytest==7.4.2",
+  "build==1.2.2.post1",
+  "pytest==8.3.3",
   "pytest-reraise==2.1.2",
-  "black==23.9.1",
-  "ruff==0.0.292",
+  "black==24.10.0",
+  "ruff==0.7.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ build_args = ["-j"]
 install_components = ["python_modules"]
 
 
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "ppc64le", "s390x", "armv7l"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "universal2", "arm64"]
+
+
 [tool.black]
 target-version = ["py312"]  # no support for 3.13 yet
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,17 @@ build_args = ["-j"]
 install_components = ["python_modules"]
 
 
+[tool.cibuildwheel]
+build-frontend = "build"
+free-threaded-support = true
+test-requires = ".[dev]"
+test-command = "pytest {project}"
+
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "ppc64le", "s390x", "armv7l"]
+archs = ["x86_64"]
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "universal2", "arm64"]
+archs = ["x86_64", "arm64"]
 
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,12 @@ install_components = ["python_modules"]
 
 
 [tool.black]
-target-version = ["py312"]  # no support for 3.13 yet
+target-version = ["py313"]
 line-length = 120
 skip-string-normalization = true
 
 [tool.ruff]
-target-version = "py312"  # no support for 3.13 yet
+target-version = "py313"
 line-length = 120
 
 [lint]

--- a/src/cereggii/__about__.py
+++ b/src/cereggii/__about__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.3.1"
+__version__ = "0.3.0"
 
 major, minor, patch, *_ = __version__.split(".")
 

--- a/src/cereggii/__init__.py
+++ b/src/cereggii/__init__.py
@@ -6,9 +6,6 @@
 Thread synchronization utilities for free-threaded Python.
 """
 
-import sys
-import warnings
-
 from .__about__ import __license__, __version__, __version_tuple__  # noqa: F401
 from .atomic_dict import AtomicDict  # noqa: F401
 from .atomic_int import AtomicInt, AtomicIntHandle  # noqa: F401

--- a/src/cereggii/_cereggii.pyi
+++ b/src/cereggii/_cereggii.pyi
@@ -1,5 +1,5 @@
-from collections.abc import Iterable, Iterator
-from typing import Callable, NewType, SupportsComplex, SupportsFloat, SupportsInt
+from collections.abc import Iterable, Iterator, Callable
+from typing import NewType, SupportsComplex, SupportsFloat, SupportsInt
 
 Key = NewType("Key", object)
 Value = NewType("Value", object)

--- a/src/cereggii/_cereggii.pyi
+++ b/src/cereggii/_cereggii.pyi
@@ -137,6 +137,7 @@ class AtomicDict:
 
         :returns: the input :param:`batch` dictionary, with substituted values.
         """
+
     def reduce(
         self,
         iterable: Iterable[tuple[Key, Value]],
@@ -167,6 +168,7 @@ class AtomicDict:
 
             d.reduce(data, count)
         """
+
     def compact(self) -> None: ...
     def debug(self) -> dict: ...
     def rehash(self, o: object) -> int: ...
@@ -197,26 +199,35 @@ class AtomicInt(int):
     def get_handle(self) -> AtomicIntHandle: ...
     def __itruediv__(self, other):
         raise NotImplementedError
+
     def as_integer_ratio(self):
         raise NotImplementedError
+
     def bit_length(self):
         raise NotImplementedError
+
     def conjugate(self):
         raise NotImplementedError
+
     @classmethod
     def from_bytes(cls, *args, **kwargs):
         raise NotImplementedError
+
     def to_bytes(self, *args, **kwargs):
         raise NotImplementedError
+
     @property
     def denominator(self):
         raise NotImplementedError
+
     @property
     def numerator(self):
         raise NotImplementedError
+
     @property
     def imag(self):
         raise NotImplementedError
+
     @property
     def real(self):
         raise NotImplementedError

--- a/src/cereggii/atomic_dict/accessor_storage.c
+++ b/src/cereggii/atomic_dict/accessor_storage.c
@@ -36,13 +36,13 @@ AtomicDict_GetOrCreateAccessorStorage(AtomicDict *self)
 
         if (appended == -1)
             goto fail;
-//        Py_DECREF(storage);
+        Py_DECREF(storage);
     }
 
     return storage;
     fail:
     assert(storage != NULL);
-//    Py_DECREF(storage);
+    Py_DECREF(storage);
     return NULL;
 }
 

--- a/src/cereggii/atomic_dict/accessor_storage.c
+++ b/src/cereggii/atomic_dict/accessor_storage.c
@@ -36,13 +36,13 @@ AtomicDict_GetOrCreateAccessorStorage(AtomicDict *self)
 
         if (appended == -1)
             goto fail;
-        Py_DECREF(storage);
+//        Py_DECREF(storage);
     }
 
     return storage;
     fail:
     assert(storage != NULL);
-    Py_DECREF(storage);
+//    Py_DECREF(storage);
     return NULL;
 }
 

--- a/src/cereggii/atomic_dict/accessor_storage.c
+++ b/src/cereggii/atomic_dict/accessor_storage.c
@@ -62,7 +62,7 @@ AtomicDict_BeginSynchronousOperation(AtomicDict *self)
     PyMutex_Lock(&self->accessors_lock);
     for (Py_ssize_t i = 0; i < PyList_Size(self->accessors); ++i) {
         AtomicDict_AccessorStorage *storage = NULL;
-        storage = (AtomicDict_AccessorStorage *) PyList_GetItem(self->accessors, i);
+        storage = (AtomicDict_AccessorStorage *) PyList_GetItemRef(self->accessors, i);
         assert(storage != NULL);
 
         PyMutex_Lock(&storage->self_mutex);
@@ -75,7 +75,7 @@ AtomicDict_EndSynchronousOperation(AtomicDict *self)
     PyMutex_Unlock(&self->sync_op);
     for (Py_ssize_t i = 0; i < PyList_Size(self->accessors); ++i) {
         AtomicDict_AccessorStorage *storage = NULL;
-        storage = (AtomicDict_AccessorStorage *) PyList_GetItem(self->accessors, i);
+        storage = (AtomicDict_AccessorStorage *) PyList_GetItemRef(self->accessors, i);
         assert(storage != NULL);
 
         PyMutex_Unlock(&storage->self_mutex);

--- a/src/cereggii/atomic_dict/atomic_dict.c
+++ b/src/cereggii/atomic_dict/atomic_dict.c
@@ -44,9 +44,9 @@ AtomicDict_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSE
     return (PyObject *) self;
 
     fail:
-//    Py_XDECREF(self->metadata);
-//    Py_XDECREF(self->accessors);
-//    Py_XDECREF(self);
+    Py_XDECREF(self->metadata);
+    Py_XDECREF(self->accessors);
+    Py_XDECREF(self);
     return NULL;
 }
 
@@ -219,7 +219,7 @@ AtomicDict_init(AtomicDict *self, PyObject *args, PyObject *kwargs)
             entry->value = value;
             int inserted = AtomicDict_UnsafeInsert(meta, hash, self->len);
             if (inserted == -1) {
-//                Py_DECREF(meta);
+                Py_DECREF(meta);
                 log_size++;
                 goto create;
             }
@@ -283,11 +283,11 @@ AtomicDict_init(AtomicDict *self, PyObject *args, PyObject *kwargs)
         }
     }
 
-//    Py_DECREF(meta); // so that the only meta's refcount depends only on AtomicRef
-//    assert(Py_REFCNT(meta) == 1);
+    Py_DECREF(meta); // so that the only meta's refcount depends only on AtomicRef
+    assert(Py_REFCNT(meta) == 1);
     return 0;
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     if (!PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError, "error during initialization.");
     }
@@ -422,7 +422,7 @@ AtomicDict_LenBounds(AtomicDict *self)
         // visit the grb
         found += AtomicDict_CountKeysInBlock(grb, meta);
     }
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     meta = NULL;
 
     if (supposedly_full_blocks < 0) {
@@ -453,7 +453,7 @@ AtomicDict_LenBounds(AtomicDict *self)
     return Py_BuildValue("(ll)", lower + found, upper + found);
 
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     return NULL;
 }
 
@@ -482,18 +482,18 @@ AtomicDict_ApproxLen(AtomicDict *self)
     avg = PyNumber_FloorDivide(sum, PyLong_FromLong(2));
     // PyLong_FromLong(2) will not return NULL
 
-//    Py_DECREF(bounds);
-//    Py_DECREF(lower);
-//    Py_DECREF(upper);
-//    Py_DECREF(sum);
+    Py_DECREF(bounds);
+    Py_DECREF(lower);
+    Py_DECREF(upper);
+    Py_DECREF(sum);
     return avg;
 
     fail:
-//    Py_XDECREF(bounds);
-//    Py_XDECREF(lower);
-//    Py_XDECREF(upper);
-//    Py_XDECREF(sum);
-//    Py_XDECREF(avg);
+    Py_XDECREF(bounds);
+    Py_XDECREF(lower);
+    Py_XDECREF(upper);
+    Py_XDECREF(sum);
+    Py_XDECREF(avg);
     return NULL;
 }
 
@@ -522,7 +522,7 @@ AtomicDict_Len_impl(AtomicDict *self)
             goto fail;
 
         len = PyNumber_InPlaceAdd(len, local_len);
-//        Py_DECREF(local_len);
+        Py_DECREF(local_len);
         local_len = NULL;
         storage->local_len = 0;
     }
@@ -533,10 +533,10 @@ AtomicDict_Len_impl(AtomicDict *self)
     self->len = int_len;
     self->len_dirty = 0;
 
-//    Py_DECREF(len);
+    Py_DECREF(len);
     return int_len;
     fail:
-//    Py_XDECREF(len);
+    Py_XDECREF(len);
     return -1;
 }
 
@@ -593,7 +593,7 @@ AtomicDict_Debug(AtomicDict *self)
         if (n == NULL)
             goto fail;
         PyList_Append(index_nodes, n);
-//        Py_DECREF(n);
+        Py_DECREF(n);
     }
 
     blocks = Py_BuildValue("[]");
@@ -629,37 +629,37 @@ AtomicDict_Debug(AtomicDict *self)
                 Py_INCREF(key);
                 Py_INCREF(value);
                 PyList_Append(entries, entry_tuple);
-//                Py_DECREF(entry_tuple);
+                Py_DECREF(entry_tuple);
             }
         }
 
         block_info = Py_BuildValue("{snsO}",
                                    "gen\0", block->generation,
                                    "entries\0", entries);
-//        Py_DECREF(entries);
+        Py_DECREF(entries);
         if (block_info == NULL)
             goto fail;
         PyList_Append(blocks, block_info);
-//        Py_DECREF(block_info);
+        Py_DECREF(block_info);
     }
 
     PyObject *out = Py_BuildValue("{sOsOsO}", "meta\0", metadata, "blocks\0", blocks, "index\0", index_nodes);
     if (out == NULL)
         goto fail;
-//    Py_DECREF(meta);
-//    Py_DECREF(metadata);
-//    Py_DECREF(blocks);
-//    Py_DECREF(index_nodes);
+    Py_DECREF(meta);
+    Py_DECREF(metadata);
+    Py_DECREF(blocks);
+    Py_DECREF(index_nodes);
     return out;
 
     fail:
     PyErr_SetString(PyExc_RuntimeError, "unable to get debug info");
-//    Py_XDECREF(meta);
-//    Py_XDECREF(metadata);
-//    Py_XDECREF(index_nodes);
-//    Py_XDECREF(blocks);
-//    Py_XDECREF(entries);
-//    Py_XDECREF(entry_tuple);
-//    Py_XDECREF(block_info);
+    Py_XDECREF(meta);
+    Py_XDECREF(metadata);
+    Py_XDECREF(index_nodes);
+    Py_XDECREF(blocks);
+    Py_XDECREF(entries);
+    Py_XDECREF(entry_tuple);
+    Py_XDECREF(block_info);
     return NULL;
 }

--- a/src/cereggii/atomic_dict/atomic_dict.c
+++ b/src/cereggii/atomic_dict/atomic_dict.c
@@ -44,9 +44,9 @@ AtomicDict_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSE
     return (PyObject *) self;
 
     fail:
-    Py_XDECREF(self->metadata);
-    Py_XDECREF(self->accessors);
-    Py_XDECREF(self);
+//    Py_XDECREF(self->metadata);
+//    Py_XDECREF(self->accessors);
+//    Py_XDECREF(self);
     return NULL;
 }
 
@@ -219,7 +219,7 @@ AtomicDict_init(AtomicDict *self, PyObject *args, PyObject *kwargs)
             entry->value = value;
             int inserted = AtomicDict_UnsafeInsert(meta, hash, self->len);
             if (inserted == -1) {
-                Py_DECREF(meta);
+//                Py_DECREF(meta);
                 log_size++;
                 goto create;
             }
@@ -283,11 +283,11 @@ AtomicDict_init(AtomicDict *self, PyObject *args, PyObject *kwargs)
         }
     }
 
-    Py_DECREF(meta); // so that the only meta's refcount depends only on AtomicRef
-    assert(Py_REFCNT(meta) == 1);
+//    Py_DECREF(meta); // so that the only meta's refcount depends only on AtomicRef
+//    assert(Py_REFCNT(meta) == 1);
     return 0;
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     if (!PyErr_Occurred()) {
         PyErr_SetString(PyExc_RuntimeError, "error during initialization.");
     }
@@ -422,7 +422,7 @@ AtomicDict_LenBounds(AtomicDict *self)
         // visit the grb
         found += AtomicDict_CountKeysInBlock(grb, meta);
     }
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     meta = NULL;
 
     if (supposedly_full_blocks < 0) {
@@ -451,7 +451,7 @@ AtomicDict_LenBounds(AtomicDict *self)
     return Py_BuildValue("(ll)", lower + found, upper + found);
 
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     return NULL;
 }
 
@@ -480,18 +480,18 @@ AtomicDict_ApproxLen(AtomicDict *self)
     avg = PyNumber_FloorDivide(sum, PyLong_FromLong(2));
     // PyLong_FromLong(2) will not return NULL
 
-    Py_DECREF(bounds);
-    Py_DECREF(lower);
-    Py_DECREF(upper);
-    Py_DECREF(sum);
+//    Py_DECREF(bounds);
+//    Py_DECREF(lower);
+//    Py_DECREF(upper);
+//    Py_DECREF(sum);
     return avg;
 
     fail:
-    Py_XDECREF(bounds);
-    Py_XDECREF(lower);
-    Py_XDECREF(upper);
-    Py_XDECREF(sum);
-    Py_XDECREF(avg);
+//    Py_XDECREF(bounds);
+//    Py_XDECREF(lower);
+//    Py_XDECREF(upper);
+//    Py_XDECREF(sum);
+//    Py_XDECREF(avg);
     return NULL;
 }
 
@@ -520,7 +520,7 @@ AtomicDict_Len_impl(AtomicDict *self)
             goto fail;
 
         len = PyNumber_InPlaceAdd(len, local_len);
-        Py_DECREF(local_len);
+//        Py_DECREF(local_len);
         local_len = NULL;
         storage->local_len = 0;
     }
@@ -531,10 +531,10 @@ AtomicDict_Len_impl(AtomicDict *self)
     self->len = int_len;
     self->len_dirty = 0;
 
-    Py_DECREF(len);
+//    Py_DECREF(len);
     return int_len;
     fail:
-    Py_XDECREF(len);
+//    Py_XDECREF(len);
     return -1;
 }
 
@@ -591,7 +591,7 @@ AtomicDict_Debug(AtomicDict *self)
         if (n == NULL)
             goto fail;
         PyList_Append(index_nodes, n);
-        Py_DECREF(n);
+//        Py_DECREF(n);
     }
 
     blocks = Py_BuildValue("[]");
@@ -627,37 +627,37 @@ AtomicDict_Debug(AtomicDict *self)
                 Py_INCREF(key);
                 Py_INCREF(value);
                 PyList_Append(entries, entry_tuple);
-                Py_DECREF(entry_tuple);
+//                Py_DECREF(entry_tuple);
             }
         }
 
         block_info = Py_BuildValue("{snsO}",
                                    "gen\0", block->generation,
                                    "entries\0", entries);
-        Py_DECREF(entries);
+//        Py_DECREF(entries);
         if (block_info == NULL)
             goto fail;
         PyList_Append(blocks, block_info);
-        Py_DECREF(block_info);
+//        Py_DECREF(block_info);
     }
 
     PyObject *out = Py_BuildValue("{sOsOsO}", "meta\0", metadata, "blocks\0", blocks, "index\0", index_nodes);
     if (out == NULL)
         goto fail;
-    Py_DECREF(meta);
-    Py_DECREF(metadata);
-    Py_DECREF(blocks);
-    Py_DECREF(index_nodes);
+//    Py_DECREF(meta);
+//    Py_DECREF(metadata);
+//    Py_DECREF(blocks);
+//    Py_DECREF(index_nodes);
     return out;
 
     fail:
     PyErr_SetString(PyExc_RuntimeError, "unable to get debug info");
-    Py_XDECREF(meta);
-    Py_XDECREF(metadata);
-    Py_XDECREF(index_nodes);
-    Py_XDECREF(blocks);
-    Py_XDECREF(entries);
-    Py_XDECREF(entry_tuple);
-    Py_XDECREF(block_info);
+//    Py_XDECREF(meta);
+//    Py_XDECREF(metadata);
+//    Py_XDECREF(index_nodes);
+//    Py_XDECREF(blocks);
+//    Py_XDECREF(entries);
+//    Py_XDECREF(entry_tuple);
+//    Py_XDECREF(block_info);
     return NULL;
 }

--- a/src/cereggii/atomic_dict/atomic_dict.c
+++ b/src/cereggii/atomic_dict/atomic_dict.c
@@ -554,7 +554,7 @@ AtomicDict_Debug(AtomicDict *self)
     meta = (AtomicDict_Meta *) AtomicRef_Get(self->metadata);
     metadata = Py_BuildValue("{sOsOsOsOsOsOsOsOsOsOsOsOsOsOsO}",
                              "log_size\0", Py_BuildValue("B", meta->log_size),
-                             "generation\0", Py_BuildValue("O", meta->generation),
+                             "generation\0", Py_BuildValue("n", (Py_ssize_t) meta->generation),
                              "node_size\0", Py_BuildValue("B", meta->node_size),
                              "distance_size\0", Py_BuildValue("B", meta->distance_size),
                              "tag_size\0", Py_BuildValue("B", meta->tag_size),
@@ -622,7 +622,7 @@ AtomicDict_Debug(AtomicDict *self)
             }
         }
 
-        block_info = Py_BuildValue("{sOsO}",
+        block_info = Py_BuildValue("{snsO}",
                                    "gen\0", block->generation,
                                    "entries\0", entries);
         Py_DECREF(entries);

--- a/src/cereggii/atomic_dict/atomic_dict.c
+++ b/src/cereggii/atomic_dict/atomic_dict.c
@@ -202,6 +202,8 @@ AtomicDict_init(AtomicDict *self, PyObject *args, PyObject *kwargs)
         Py_hash_t hash;
         Py_ssize_t pos = 0;
 
+        Py_BEGIN_CRITICAL_SECTION(init_dict);
+
         while (PyDict_Next(init_dict, &pos, &key, &value)) {
             hash = PyObject_Hash(key);
             if (hash == -1)
@@ -222,6 +224,9 @@ AtomicDict_init(AtomicDict *self, PyObject *args, PyObject *kwargs)
                 goto create;
             }
         }
+
+        Py_END_CRITICAL_SECTION();
+
         meta->inserting_block = self->len >> ATOMIC_DICT_LOG_ENTRIES_IN_BLOCK;
 
         if (self->len > 0) {

--- a/src/cereggii/atomic_dict/atomic_dict.c
+++ b/src/cereggii/atomic_dict/atomic_dict.c
@@ -395,7 +395,6 @@ AtomicDict_LenBounds(AtomicDict *self)
     int64_t gab = meta->greatest_allocated_block + 1;
     int64_t gdb = meta->greatest_deleted_block + 1;
     int64_t grb = meta->greatest_refilled_block + 1;
-    // todo: handle greedy alloc
 
     int64_t supposedly_full_blocks = (gab - gdb + grb - 1);
 

--- a/src/cereggii/atomic_dict/blocks.c
+++ b/src/cereggii/atomic_dict/blocks.c
@@ -6,9 +6,7 @@
 
 #include "atomic_dict.h"
 #include "atomic_dict_internal.h"
-#include "atomic_ref.h"
 #include "atomic_ops.h"
-#include "pythread.h"
 
 
 AtomicDict_Block *
@@ -30,8 +28,6 @@ AtomicDictBlock_New(AtomicDict_Meta *meta)
 void
 AtomicDictBlock_dealloc(AtomicDict_Block *self)
 {
-//    printf("dealloc %p ", self);
-//    fflush(stdout);
     Py_CLEAR(self->generation);
 
     AtomicDict_Entry entry;

--- a/src/cereggii/atomic_dict/blocks.c
+++ b/src/cereggii/atomic_dict/blocks.c
@@ -18,7 +18,6 @@ AtomicDictBlock_New(AtomicDict_Meta *meta)
     if (new == NULL)
         return NULL;
 
-    Py_INCREF(meta->generation);
     new->generation = meta->generation;
     memset(new->entries, 0, sizeof(AtomicDict_Entry) * ATOMIC_DICT_ENTRIES_IN_BLOCK);
 

--- a/src/cereggii/atomic_dict/blocks.c
+++ b/src/cereggii/atomic_dict/blocks.c
@@ -54,9 +54,9 @@ AtomicDictBlock_clear(AtomicDict_Block *self)
             continue;
 
         self->entries[i].key = NULL;
-        Py_XDECREF(entry.key);
+//        Py_XDECREF(entry.key);
         self->entries[i].value = NULL;
-        Py_XDECREF(entry.value);
+//        Py_XDECREF(entry.value);
     }
 
     return 0;
@@ -136,7 +136,7 @@ AtomicDict_GetEmptyEntry(AtomicDict *self, AtomicDict_Meta *meta, AtomicDict_Res
             AtomicDict_ReservationBufferPut(rb, entry_loc, self->reservation_buffer_size);
             AtomicDict_ReservationBufferPop(rb, entry_loc);
         } else {
-            Py_DECREF(block);
+//            Py_DECREF(block);
             goto reserve_in_inserting_block;
         }
     }

--- a/src/cereggii/atomic_dict/blocks.c
+++ b/src/cereggii/atomic_dict/blocks.c
@@ -54,9 +54,9 @@ AtomicDictBlock_clear(AtomicDict_Block *self)
             continue;
 
         self->entries[i].key = NULL;
-//        Py_XDECREF(entry.key);
+        Py_XDECREF(entry.key);
         self->entries[i].value = NULL;
-//        Py_XDECREF(entry.value);
+        Py_XDECREF(entry.value);
     }
 
     return 0;
@@ -136,7 +136,7 @@ AtomicDict_GetEmptyEntry(AtomicDict *self, AtomicDict_Meta *meta, AtomicDict_Res
             AtomicDict_ReservationBufferPut(rb, entry_loc, self->reservation_buffer_size);
             AtomicDict_ReservationBufferPop(rb, entry_loc);
         } else {
-//            Py_DECREF(block);
+            Py_DECREF(block);
             goto reserve_in_inserting_block;
         }
     }

--- a/src/cereggii/atomic_dict/blocks.c
+++ b/src/cereggii/atomic_dict/blocks.c
@@ -28,8 +28,6 @@ AtomicDictBlock_New(AtomicDict_Meta *meta)
 void
 AtomicDictBlock_dealloc(AtomicDict_Block *self)
 {
-    Py_CLEAR(self->generation);
-
     AtomicDict_Entry entry;
     for (int i = 0; i < ATOMIC_DICT_ENTRIES_IN_BLOCK; ++i) {
         entry = self->entries[i];

--- a/src/cereggii/atomic_dict/delete.c
+++ b/src/cereggii/atomic_dict/delete.c
@@ -40,8 +40,8 @@ AtomicDict_Delete(AtomicDict_Meta *meta, PyObject *key, Py_hash_t hash)
             goto not_found;
     }
 
-//    Py_CLEAR(result.entry_p->key);
-//    Py_DECREF(result.entry.value);
+    Py_CLEAR(result.entry_p->key);
+    Py_DECREF(result.entry.value);
     result.entry.value = NULL;
 
 //    do {
@@ -193,7 +193,7 @@ AtomicDict_DelItem(AtomicDict *self, PyObject *key)
     int migrated = AtomicDict_MaybeHelpMigrate(meta, &storage->self_mutex);
     if (migrated) {
         // self_mutex was unlocked during the operation
-//        Py_DECREF(meta);
+        Py_DECREF(meta);
         meta = NULL;
         goto beginning;
     }
@@ -221,10 +221,10 @@ AtomicDict_DelItem(AtomicDict *self, PyObject *key)
             goto fail;
     }
 
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     return 0;
 
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     return -1;
 }

--- a/src/cereggii/atomic_dict/delete.c
+++ b/src/cereggii/atomic_dict/delete.c
@@ -40,8 +40,8 @@ AtomicDict_Delete(AtomicDict_Meta *meta, PyObject *key, Py_hash_t hash)
             goto not_found;
     }
 
-    Py_CLEAR(result.entry_p->key);
-    Py_DECREF(result.entry.value);
+//    Py_CLEAR(result.entry_p->key);
+//    Py_DECREF(result.entry.value);
     result.entry.value = NULL;
 
 //    do {
@@ -193,7 +193,7 @@ AtomicDict_DelItem(AtomicDict *self, PyObject *key)
     int migrated = AtomicDict_MaybeHelpMigrate(meta, &storage->self_mutex);
     if (migrated) {
         // self_mutex was unlocked during the operation
-        Py_DECREF(meta);
+//        Py_DECREF(meta);
         meta = NULL;
         goto beginning;
     }
@@ -221,10 +221,10 @@ AtomicDict_DelItem(AtomicDict *self, PyObject *key)
             goto fail;
     }
 
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     return 0;
 
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     return -1;
 }

--- a/src/cereggii/atomic_dict/insert.c
+++ b/src/cereggii/atomic_dict/insert.c
@@ -363,7 +363,7 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
     int migrated = AtomicDict_MaybeHelpMigrate(meta, &storage->self_mutex);
     if (migrated) {
         // self_mutex was unlocked during the operation
-        Py_DECREF(meta);
+//        Py_DECREF(meta);
         meta = NULL;
         goto beginning;
     }
@@ -386,7 +386,7 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
             if (migrated < 0)
                 goto fail;
 
-            Py_DECREF(meta);
+//            Py_DECREF(meta);
             meta = NULL;
             goto beginning;
         }
@@ -424,17 +424,17 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
             goto fail;
 
         if (must_grow) {  // insertion didn't happen
-            Py_DECREF(meta);
+//            Py_DECREF(meta);
             goto beginning;
         }
     }
 
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     return result;
     fail:
-    Py_XDECREF(meta);
-    Py_DECREF(key);
-    Py_DECREF(desired);
+//    Py_XDECREF(meta);
+//    Py_DECREF(key);
+//    Py_DECREF(desired);
     return NULL;
 }
 
@@ -492,7 +492,7 @@ AtomicDict_SetItem(AtomicDict *self, PyObject *key, PyObject *value)
     assert(result != EXPECTATION_FAILED);
 
     if (result != NOT_FOUND && result != ANY && result != EXPECTATION_FAILED) {
-        Py_DECREF(result);
+//        Py_DECREF(result);
     }
 
     return 0;
@@ -598,7 +598,7 @@ reduce_flush(AtomicDict *self, PyObject *local_buffer, PyObject *aggregate)
     PyMem_RawFree(keys);
     PyMem_RawFree(expected);
     PyMem_RawFree(desired);
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     return 0;
 
     fail:
@@ -611,7 +611,7 @@ reduce_flush(AtomicDict *self, PyObject *local_buffer, PyObject *aggregate)
     if (desired != NULL) {
         PyMem_RawFree(desired);
     }
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     return -1;
 }
 
@@ -684,10 +684,10 @@ AtomicDict_Reduce(AtomicDict *self, PyObject *iterable, PyObject *aggregate, int
         if (PyDict_SetItem(local_buffer, key, tuple) < 0)
             goto fail;
 
-        Py_DECREF(item);
+//        Py_DECREF(item);
     }
 
-    Py_DECREF(iterator);
+//    Py_DECREF(iterator);
 
     if (PyErr_Occurred()) {
         goto fail;
@@ -695,12 +695,12 @@ AtomicDict_Reduce(AtomicDict *self, PyObject *iterable, PyObject *aggregate, int
 
     reduce_flush(self, local_buffer, aggregate);
 
-    Py_DECREF(local_buffer);
+//    Py_DECREF(local_buffer);
     return 0;
 
     fail:
-    Py_XDECREF(local_buffer);
-    Py_XDECREF(item);
+//    Py_XDECREF(local_buffer);
+//    Py_XDECREF(item);
     return -1;
 }
 

--- a/src/cereggii/atomic_dict/insert.c
+++ b/src/cereggii/atomic_dict/insert.c
@@ -332,8 +332,16 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
 
     Py_INCREF(key);
     Py_INCREF(desired);
-    _PyObject_SetMaybeWeakref(key);
-    _PyObject_SetMaybeWeakref(desired);
+#ifdef Py_GIL_DISABLED
+    if (!_Py_IsImmortal(key)) {
+        _PyObject_SetMaybeWeakref(key);
+    }
+#endif
+#ifdef Py_GIL_DISABLED
+    if (!_Py_IsImmortal(desired)) {
+        _PyObject_SetMaybeWeakref(desired);
+    }
+#endif
 
     AtomicDict_Meta *meta = NULL;
 

--- a/src/cereggii/atomic_dict/insert.c
+++ b/src/cereggii/atomic_dict/insert.c
@@ -363,7 +363,7 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
     int migrated = AtomicDict_MaybeHelpMigrate(meta, &storage->self_mutex);
     if (migrated) {
         // self_mutex was unlocked during the operation
-//        Py_DECREF(meta);
+        Py_DECREF(meta);
         meta = NULL;
         goto beginning;
     }
@@ -386,7 +386,7 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
             if (migrated < 0)
                 goto fail;
 
-//            Py_DECREF(meta);
+            Py_DECREF(meta);
             meta = NULL;
             goto beginning;
         }
@@ -424,17 +424,17 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
             goto fail;
 
         if (must_grow) {  // insertion didn't happen
-//            Py_DECREF(meta);
+            Py_DECREF(meta);
             goto beginning;
         }
     }
 
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     return result;
     fail:
-//    Py_XDECREF(meta);
-//    Py_DECREF(key);
-//    Py_DECREF(desired);
+    Py_XDECREF(meta);
+    Py_DECREF(key);
+    Py_DECREF(desired);
     return NULL;
 }
 
@@ -492,7 +492,7 @@ AtomicDict_SetItem(AtomicDict *self, PyObject *key, PyObject *value)
     assert(result != EXPECTATION_FAILED);
 
     if (result != NOT_FOUND && result != ANY && result != EXPECTATION_FAILED) {
-//        Py_DECREF(result);
+        Py_DECREF(result);
     }
 
     return 0;
@@ -598,7 +598,7 @@ reduce_flush(AtomicDict *self, PyObject *local_buffer, PyObject *aggregate)
     PyMem_RawFree(keys);
     PyMem_RawFree(expected);
     PyMem_RawFree(desired);
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     return 0;
 
     fail:
@@ -611,7 +611,7 @@ reduce_flush(AtomicDict *self, PyObject *local_buffer, PyObject *aggregate)
     if (desired != NULL) {
         PyMem_RawFree(desired);
     }
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     return -1;
 }
 
@@ -684,10 +684,10 @@ AtomicDict_Reduce(AtomicDict *self, PyObject *iterable, PyObject *aggregate, int
         if (PyDict_SetItem(local_buffer, key, tuple) < 0)
             goto fail;
 
-//        Py_DECREF(item);
+        Py_DECREF(item);
     }
 
-//    Py_DECREF(iterator);
+    Py_DECREF(iterator);
 
     if (PyErr_Occurred()) {
         goto fail;
@@ -695,12 +695,12 @@ AtomicDict_Reduce(AtomicDict *self, PyObject *iterable, PyObject *aggregate, int
 
     reduce_flush(self, local_buffer, aggregate);
 
-//    Py_DECREF(local_buffer);
+    Py_DECREF(local_buffer);
     return 0;
 
     fail:
-//    Py_XDECREF(local_buffer);
-//    Py_XDECREF(item);
+    Py_XDECREF(local_buffer);
+    Py_XDECREF(item);
     return -1;
 }
 

--- a/src/cereggii/atomic_dict/insert.c
+++ b/src/cereggii/atomic_dict/insert.c
@@ -652,7 +652,9 @@ AtomicDict_Reduce(AtomicDict *self, PyObject *iterable, PyObject *aggregate, int
         key = PyTuple_GetItem(item, 0);
         value = PyTuple_GetItem(item, 1);
         if (PyDict_Contains(local_buffer, key)) {
-            current = PyDict_GetItem(local_buffer, key);
+            if (PyDict_GetItemRef(local_buffer, key, &current) < 0)
+                goto fail;
+
             expected = PyTuple_GetItem(current, 0);
             current = PyTuple_GetItem(current, 1);
         } else {

--- a/src/cereggii/atomic_dict/insert.c
+++ b/src/cereggii/atomic_dict/insert.c
@@ -9,6 +9,7 @@
 #include "atomic_ref.h"
 #include "atomic_ops.h"
 #include "pythread.h"
+#include "_internal_py_core.h"
 
 
 int
@@ -331,6 +332,8 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
 
     Py_INCREF(key);
     Py_INCREF(desired);
+    _PyObject_SetMaybeWeakref(key);
+    _PyObject_SetMaybeWeakref(desired);
 
     AtomicDict_Meta *meta = NULL;
 

--- a/src/cereggii/atomic_dict/iter.c
+++ b/src/cereggii/atomic_dict/iter.c
@@ -47,8 +47,8 @@ AtomicDict_FastIter(AtomicDict *self, PyObject *args, PyObject *kwargs)
     return (PyObject *) iter;
 
     fail:
-//    Py_XDECREF(iter);
-//    Py_DECREF(self);
+    Py_XDECREF(iter);
+    Py_DECREF(self);
     fail_parse:
     return NULL;
 }

--- a/src/cereggii/atomic_dict/iter.c
+++ b/src/cereggii/atomic_dict/iter.c
@@ -47,8 +47,8 @@ AtomicDict_FastIter(AtomicDict *self, PyObject *args, PyObject *kwargs)
     return (PyObject *) iter;
 
     fail:
-    Py_XDECREF(iter);
-    Py_DECREF(self);
+//    Py_XDECREF(iter);
+//    Py_DECREF(self);
     fail_parse:
     return NULL;
 }

--- a/src/cereggii/atomic_dict/lookup.c
+++ b/src/cereggii/atomic_dict/lookup.c
@@ -172,19 +172,19 @@ AtomicDict_GetItemOrDefault(AtomicDict *self, PyObject *key, PyObject *default_v
         goto fail;
 
     if (AtomicRef_Get(self->metadata) != (PyObject *) meta) {
-//        Py_DECREF(meta);
+        Py_DECREF(meta);
         goto retry;
     }
-//    Py_DECREF(meta); // for AtomicRef_Get (if condition)
+    Py_DECREF(meta); // for AtomicRef_Get (if condition)
 
     if (result.entry_p == NULL) {
         result.entry.value = default_value;
     }
 
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     return result.entry.value;
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     return NULL;
 }
 
@@ -331,17 +331,17 @@ AtomicDict_BatchGetItem(AtomicDict *self, PyObject *args, PyObject *kwargs)
     Py_END_CRITICAL_SECTION();
 
     if (self->metadata->reference != (PyObject *) meta) {
-//        Py_DECREF(meta);
+        Py_DECREF(meta);
         goto retry;
     }
 
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     PyMem_RawFree(hashes);
     PyMem_RawFree(keys);
     Py_INCREF(batch);
     return batch;
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     if (hashes != NULL) {
         PyMem_RawFree(hashes);
     }

--- a/src/cereggii/atomic_dict/lookup.c
+++ b/src/cereggii/atomic_dict/lookup.c
@@ -7,9 +7,6 @@
 #include "atomic_dict.h"
 #include "atomic_dict_internal.h"
 #include "constants.h"
-#define Py_BUILD_CORE
-#include "internal/pycore_dict.h"
-#undef Py_BUILD_CORE
 
 
 void
@@ -316,10 +313,10 @@ AtomicDict_BatchGetItem(AtomicDict *self, PyObject *args, PyObject *kwargs)
 
         assert(_PyDict_GetItem_KnownHash(batch, key, hash) != NULL); // returns a borrowed reference
         if (result.found) {
-            if (_PyDict_SetItem_KnownHash(batch, key, result.entry.value, hash) < 0)
+            if (PyDict_SetItem(batch, key, result.entry.value) < 0)
                 goto fail;
         } else {
-            if (_PyDict_SetItem_KnownHash(batch, key, NOT_FOUND, hash) < 0)
+            if (PyDict_SetItem(batch, key, NOT_FOUND) < 0)
                 goto fail;
         }
     }

--- a/src/cereggii/atomic_dict/lookup.c
+++ b/src/cereggii/atomic_dict/lookup.c
@@ -243,6 +243,7 @@ AtomicDict_BatchGetItem(AtomicDict *self, PyObject *args, PyObject *kwargs)
     Py_hash_t hash;
     Py_hash_t *hashes = NULL;
     PyObject **keys = NULL;
+    AtomicDict_Meta *meta = NULL;
 
     hashes = PyMem_RawMalloc(chunk_size * sizeof(Py_hash_t));
     if (hashes == NULL)
@@ -253,7 +254,6 @@ AtomicDict_BatchGetItem(AtomicDict *self, PyObject *args, PyObject *kwargs)
         goto fail;
 
     AtomicDict_SearchResult result;
-    AtomicDict_Meta *meta = NULL;
     retry:
     meta = (AtomicDict_Meta *) AtomicRef_Get(self->metadata);
 
@@ -262,6 +262,8 @@ AtomicDict_BatchGetItem(AtomicDict *self, PyObject *args, PyObject *kwargs)
 
     Py_ssize_t chunk_start = 0, chunk_end = 0;
     Py_ssize_t pos = 0;
+
+    Py_BEGIN_CRITICAL_SECTION(batch);
 
     next_chunk:
     while (PyDict_Next(batch, &pos, &key, &value)) {
@@ -325,6 +327,8 @@ AtomicDict_BatchGetItem(AtomicDict *self, PyObject *args, PyObject *kwargs)
         chunk_start = chunk_end;
         goto next_chunk;
     }
+
+    Py_END_CRITICAL_SECTION();
 
     if (self->metadata->reference != (PyObject *) meta) {
         Py_DECREF(meta);

--- a/src/cereggii/atomic_dict/lookup.c
+++ b/src/cereggii/atomic_dict/lookup.c
@@ -172,19 +172,19 @@ AtomicDict_GetItemOrDefault(AtomicDict *self, PyObject *key, PyObject *default_v
         goto fail;
 
     if (AtomicRef_Get(self->metadata) != (PyObject *) meta) {
-        Py_DECREF(meta);
+//        Py_DECREF(meta);
         goto retry;
     }
-    Py_DECREF(meta); // for AtomicRef_Get (if condition)
+//    Py_DECREF(meta); // for AtomicRef_Get (if condition)
 
     if (result.entry_p == NULL) {
         result.entry.value = default_value;
     }
 
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     return result.entry.value;
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     return NULL;
 }
 
@@ -331,17 +331,17 @@ AtomicDict_BatchGetItem(AtomicDict *self, PyObject *args, PyObject *kwargs)
     Py_END_CRITICAL_SECTION();
 
     if (self->metadata->reference != (PyObject *) meta) {
-        Py_DECREF(meta);
+//        Py_DECREF(meta);
         goto retry;
     }
 
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     PyMem_RawFree(hashes);
     PyMem_RawFree(keys);
     Py_INCREF(batch);
     return batch;
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     if (hashes != NULL) {
         PyMem_RawFree(hashes);
     }

--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -116,7 +116,7 @@ AtomicDictMeta_New(uint8_t log_size)
     return meta;
     fail:
     PyMem_RawFree(generation);
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     if (index != NULL) {
         PyMem_RawFree(index);
     }

--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -28,12 +28,15 @@ AtomicDictMeta_New(uint8_t log_size)
     if (index == NULL)
         goto fail;
 
-    meta = PyObject_New(AtomicDict_Meta, &AtomicDictMeta_Type);
+    meta = PyObject_GC_New(AtomicDict_Meta, &AtomicDictMeta_Type);
     if (meta == NULL)
         goto fail;
-    PyObject_GC_Track(meta);
 
     meta->blocks = NULL;
+    meta->greatest_allocated_block = -1;
+    meta->greatest_deleted_block = -1;
+    meta->greatest_refilled_block = -1;
+    meta->inserting_block = -1;
 
     meta->log_size = log_size;
     meta->size = 1UL << log_size;
@@ -109,6 +112,7 @@ AtomicDictMeta_New(uint8_t log_size)
     if (meta->migration_done == NULL)
         goto fail;
 
+    PyObject_GC_Track(meta);
     return meta;
     fail:
     PyMem_RawFree(generation);
@@ -132,7 +136,7 @@ AtomicDictMeta_InitBlocks(AtomicDict_Meta *meta)
     // here we're abusing virtual memory:
     // the entire array will not necessarily be allocated to physical memory.
     blocks = PyMem_RawMalloc(sizeof(AtomicDict_Block *) * (meta->size >> ATOMIC_DICT_LOG_ENTRIES_IN_BLOCK));
-    if (blocks < 0)
+    if (blocks == NULL)
         goto fail;
 
     blocks[0] = NULL;
@@ -233,13 +237,30 @@ AtomicDictMeta_ShrinkBlocks(AtomicDict *self, AtomicDict_Meta *from_meta, Atomic
     }
 }
 
-
 int
 AtomicDictMeta_traverse(AtomicDict_Meta *self, visitproc visit, void *arg)
 {
+    if (self->blocks == NULL)
+        return 0;
+
     for (uint64_t block_i = 0; block_i <= self->greatest_allocated_block; ++block_i) {
         Py_VISIT(self->blocks[block_i]);
     }
+    return 0;
+}
+
+int
+AtomicDictMeta_clear(AtomicDict_Meta *self)
+{
+    for (uint64_t block_i = 0; block_i <= self->greatest_allocated_block; ++block_i) {
+        Py_CLEAR(self->blocks[block_i]);
+    }
+
+    Py_CLEAR(self->new_gen_metadata);
+    Py_CLEAR(self->new_metadata_ready);
+    Py_CLEAR(self->node_migration_done);
+    Py_CLEAR(self->migration_done);
+
     return 0;
 }
 
@@ -247,6 +268,9 @@ void
 AtomicDictMeta_dealloc(AtomicDict_Meta *self)
 {
     PyObject_GC_UnTrack(self);
+
+    AtomicDictMeta_clear(self);
+
     uint64_t *index = self->index;
     if (index != NULL) {
         self->index = NULL;
@@ -254,17 +278,9 @@ AtomicDictMeta_dealloc(AtomicDict_Meta *self)
     }
 
     if (self->blocks != NULL) {
-        for (uint64_t block_i = 0; block_i <= self->greatest_allocated_block; ++block_i) {
-            Py_DECREF(self->blocks[block_i]);
-        }
-
         PyMem_RawFree(self->blocks);
     }
 
     PyMem_RawFree(self->generation);
-    Py_CLEAR(self->new_gen_metadata);
-    Py_CLEAR(self->new_metadata_ready);
-    Py_CLEAR(self->node_migration_done);
-    Py_CLEAR(self->migration_done);
     Py_TYPE(self)->tp_free((PyObject *) self);
 }

--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -211,7 +211,7 @@ AtomicDictMeta_ShrinkBlocks(AtomicDict *self, AtomicDict_Meta *from_meta, Atomic
         to_meta->blocks[block_j] = from_meta->blocks[block_i];
 
         for (Py_ssize_t i = 0; i < PyList_Size(self->accessors); ++i) {
-            AtomicDict_AccessorStorage *storage = (AtomicDict_AccessorStorage *) PyList_GetItem(self->accessors, i);
+            AtomicDict_AccessorStorage *storage = (AtomicDict_AccessorStorage *) PyList_GetItemRef(self->accessors, i);
             assert(storage != NULL);
 
             AtomicDict_UpdateBlocksInReservationBuffer(&storage->reservation_buffer, block_i, block_j);

--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -31,7 +31,6 @@ AtomicDictMeta_New(uint8_t log_size)
     meta = PyObject_New(AtomicDict_Meta, &AtomicDictMeta_Type);
     if (meta == NULL)
         goto fail;
-    PyObject_Init((PyObject *) meta, &AtomicDictMeta_Type);
 
     meta->blocks = NULL;
 

--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -18,7 +18,7 @@ AtomicDictMeta_New(uint8_t log_size)
 
     AtomicDict_NodeSizeInfo node_sizes = AtomicDict_NodeSizesTable[log_size];
 
-    generation = PyObject_CallObject((PyObject *) &PyBaseObject_Type, NULL);
+    generation = PyMem_RawMalloc(1);
     if (generation == NULL)
         goto fail;
 
@@ -251,7 +251,7 @@ AtomicDictMeta_dealloc(AtomicDict_Meta *self)
         PyMem_RawFree(self->blocks);
     }
 
-    Py_CLEAR(self->generation);
+    PyMem_RawFree(self->generation);
     Py_CLEAR(self->new_gen_metadata);
     Py_CLEAR(self->new_metadata_ready);
     Py_CLEAR(self->node_migration_done);

--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -116,7 +116,7 @@ AtomicDictMeta_New(uint8_t log_size)
     return meta;
     fail:
     PyMem_RawFree(generation);
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     if (index != NULL) {
         PyMem_RawFree(index);
     }

--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -12,7 +12,7 @@
 AtomicDict_Meta *
 AtomicDictMeta_New(uint8_t log_size)
 {
-    PyObject *generation = NULL;
+    void *generation = NULL;
     uint64_t *index = NULL;
     AtomicDict_Meta *meta = NULL;
 
@@ -111,7 +111,7 @@ AtomicDictMeta_New(uint8_t log_size)
 
     return meta;
     fail:
-    Py_XDECREF(generation);
+    PyMem_RawFree(generation);
     Py_XDECREF(meta);
     if (index != NULL) {
         PyMem_RawFree(index);

--- a/src/cereggii/atomic_dict/migrate.c
+++ b/src/cereggii/atomic_dict/migrate.c
@@ -215,7 +215,7 @@ AtomicDict_LeaderMigrate(AtomicDict *self, AtomicDict_Meta *current_meta /* borr
     if (from_log_size < to_log_size) {
         assert(holding_sync_lock);
         for (int i = 0; i < PyList_Size(self->accessors); ++i) {
-            AtomicDict_AccessorStorage *accessor = (AtomicDict_AccessorStorage *) PyList_GetItem(self->accessors, i);
+            AtomicDict_AccessorStorage *accessor = (AtomicDict_AccessorStorage *) PyList_GetItemRef(self->accessors, i);
             accessor->participant_in_migration = 0;
         }
     }
@@ -510,7 +510,7 @@ AtomicDict_NodesMigrationDone(const AtomicDict_Meta *current_meta)
 
     for (Py_ssize_t migrator = 0; migrator < PyList_Size(current_meta->accessors); ++migrator) {
         AtomicDict_AccessorStorage *storage =
-            (AtomicDict_AccessorStorage *) PyList_GetItem(current_meta->accessors, migrator);
+            (AtomicDict_AccessorStorage *) PyList_GetItemRef(current_meta->accessors, migrator);
 
         if (storage->participant_in_migration == 1) {
             done = 0;

--- a/src/cereggii/atomic_dict/migrate.c
+++ b/src/cereggii/atomic_dict/migrate.c
@@ -9,6 +9,7 @@
 #include "atomic_ref.h"
 #include "atomic_ops.h"
 #include "constants.h"
+#include "thread_id.h"
 
 
 int
@@ -129,7 +130,7 @@ AtomicDict_Migrate(AtomicDict *self, AtomicDict_Meta *current_meta /* borrowed *
     if (current_meta->migration_leader == 0) {
         int i_am_leader = CereggiiAtomic_CompareExchangeUIntPtr(
             &current_meta->migration_leader,
-            0, _Py_GetThreadLocal_Addr());
+            0, _Py_ThreadId());
         if (i_am_leader) {
             return AtomicDict_LeaderMigrate(self, current_meta, from_log_size, to_log_size);
         }
@@ -296,7 +297,7 @@ AtomicDict_QuickMigrate(AtomicDict_Meta *current_meta, AtomicDict_Meta *new_meta
 int
 AtomicDict_MigrateReInsertAll(AtomicDict_Meta *current_meta, AtomicDict_Meta *new_meta)
 {
-    uint64_t thread_id = _Py_GetThreadLocal_Addr();
+    uint64_t thread_id = _Py_ThreadId();
 
     int64_t copy_lock;
 

--- a/src/cereggii/atomic_dict/migrate.c
+++ b/src/cereggii/atomic_dict/migrate.c
@@ -24,11 +24,11 @@ AtomicDict_Grow(AtomicDict *self)
     if (migrate < 0)
         goto fail;
 
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     return migrate;
 
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     return -1;
 }
 
@@ -41,7 +41,7 @@ AtomicDict_Shrink(AtomicDict *self)
         goto fail;
 
     if (meta->log_size == self->min_log_size) {
-        Py_DECREF(meta);
+//        Py_DECREF(meta);
         return 0;
     }
 
@@ -49,11 +49,11 @@ AtomicDict_Shrink(AtomicDict *self)
     if (migrate < 0)
         goto fail;
 
-    Py_DECREF(meta);
+//    Py_DECREF(meta);
     return migrate;
 
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     return -1;
 }
 
@@ -79,17 +79,17 @@ AtomicDict_Compact(AtomicDict *self)
         if (migrate < 0)
             goto fail;
 
-        Py_DECREF(meta);
+//        Py_DECREF(meta);
         meta = (AtomicDict_Meta *) AtomicRef_Get(self->metadata);
         is_compact = meta->is_compact;
-        Py_DECREF(meta);
+//        Py_DECREF(meta);
 
     } while (!is_compact);
 
     return migrate;
 
     fail:
-    Py_XDECREF(meta);
+//    Py_XDECREF(meta);
     return -1;
 }
 
@@ -161,7 +161,7 @@ AtomicDict_LeaderMigrate(AtomicDict *self, AtomicDict_Meta *current_meta /* borr
 
     if (to_log_size < self->min_log_size) {
         to_log_size = self->min_log_size;
-        Py_DECREF(new_meta);
+//        Py_DECREF(new_meta);
         new_meta = NULL;
         goto beginning;
     }
@@ -221,7 +221,7 @@ AtomicDict_LeaderMigrate(AtomicDict *self, AtomicDict_Meta *current_meta /* borr
     }
 
     AtomicEvent_Set(current_meta->migration_done);
-    Py_DECREF(new_meta);  // this may seem strange: why decref the new meta?
+//    Py_DECREF(new_meta);  // this may seem strange: why decref the new meta?
     // the reason is that AtomicRef_CompareAndSet also increases new_meta's refcount,
     // which is exactly what we want. but the reference count was already 1, as it
     // was set during the initialization of new_meta. that's what we're decref'ing

--- a/src/cereggii/atomic_dict/migrate.c
+++ b/src/cereggii/atomic_dict/migrate.c
@@ -456,7 +456,7 @@ AtomicDict_BlockWiseMigrate(AtomicDict_Meta *current_meta, AtomicDict_Meta *new_
 
     uint64_t new_size_mask = new_meta->size - 1;
     uint64_t distance = 0;
-    uint64_t distance_0 = ULONG_LONG_MAX;
+    uint64_t distance_0 = ULLONG_MAX;
 
     for (; i < end_of_block; i++) {
         AtomicDict_ReadNodeAt(i, &node, current_meta);

--- a/src/cereggii/atomic_dict/migrate.c
+++ b/src/cereggii/atomic_dict/migrate.c
@@ -24,11 +24,11 @@ AtomicDict_Grow(AtomicDict *self)
     if (migrate < 0)
         goto fail;
 
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     return migrate;
 
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     return -1;
 }
 
@@ -41,7 +41,7 @@ AtomicDict_Shrink(AtomicDict *self)
         goto fail;
 
     if (meta->log_size == self->min_log_size) {
-//        Py_DECREF(meta);
+        Py_DECREF(meta);
         return 0;
     }
 
@@ -49,11 +49,11 @@ AtomicDict_Shrink(AtomicDict *self)
     if (migrate < 0)
         goto fail;
 
-//    Py_DECREF(meta);
+    Py_DECREF(meta);
     return migrate;
 
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     return -1;
 }
 
@@ -79,17 +79,17 @@ AtomicDict_Compact(AtomicDict *self)
         if (migrate < 0)
             goto fail;
 
-//        Py_DECREF(meta);
+        Py_DECREF(meta);
         meta = (AtomicDict_Meta *) AtomicRef_Get(self->metadata);
         is_compact = meta->is_compact;
-//        Py_DECREF(meta);
+        Py_DECREF(meta);
 
     } while (!is_compact);
 
     return migrate;
 
     fail:
-//    Py_XDECREF(meta);
+    Py_XDECREF(meta);
     return -1;
 }
 
@@ -161,7 +161,7 @@ AtomicDict_LeaderMigrate(AtomicDict *self, AtomicDict_Meta *current_meta /* borr
 
     if (to_log_size < self->min_log_size) {
         to_log_size = self->min_log_size;
-//        Py_DECREF(new_meta);
+        Py_DECREF(new_meta);
         new_meta = NULL;
         goto beginning;
     }
@@ -221,7 +221,7 @@ AtomicDict_LeaderMigrate(AtomicDict *self, AtomicDict_Meta *current_meta /* borr
     }
 
     AtomicEvent_Set(current_meta->migration_done);
-//    Py_DECREF(new_meta);  // this may seem strange: why decref the new meta?
+    Py_DECREF(new_meta);  // this may seem strange: why decref the new meta?
     // the reason is that AtomicRef_CompareAndSet also increases new_meta's refcount,
     // which is exactly what we want. but the reference count was already 1, as it
     // was set during the initialization of new_meta. that's what we're decref'ing

--- a/src/cereggii/atomic_event.c
+++ b/src/cereggii/atomic_event.c
@@ -11,7 +11,7 @@ PyObject *
 AtomicEvent_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwds))
 {
     AtomicEvent *self = NULL;
-    self = (AtomicEvent *) type->tp_alloc(type, 0);
+    self = PyObject_New(AtomicEvent, &AtomicEvent_Type);
     return (PyObject *) self;
 }
 

--- a/src/cereggii/atomic_int/atomic_int.c
+++ b/src/cereggii/atomic_int/atomic_int.c
@@ -114,16 +114,6 @@ AtomicInt_DivOrSetException(int64_t current, int64_t to_div, int64_t *result)
     return overflowed;
 }
 
-
-PyObject *
-AtomicInt_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwargs))
-{
-    AtomicInt *self;
-    self = PyObject_New(AtomicInt, &AtomicInt_Type);
-
-    return (PyObject *) self;
-}
-
 int
 AtomicInt_init(AtomicInt *self, PyObject *args, PyObject *kwargs)
 {

--- a/src/cereggii/atomic_int/atomic_int.c
+++ b/src/cereggii/atomic_int/atomic_int.c
@@ -119,7 +119,7 @@ PyObject *
 AtomicInt_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwargs))
 {
     AtomicInt *self;
-    self = (AtomicInt *) type->tp_alloc(type, 0);
+    self = PyObject_New(AtomicInt, &AtomicInt_Type);
 
     return (PyObject *) self;
 }
@@ -523,9 +523,9 @@ AtomicInt_UpdateAndGet_callable(AtomicInt *self, PyObject *callable)
 PyObject *
 AtomicInt_GetHandle(AtomicInt *self)
 {
-    PyObject *handle = NULL;
+    AtomicIntHandle *handle = NULL;
 
-    handle = AtomicIntHandle_new(&AtomicIntHandle_Type, NULL, NULL);
+    handle = PyObject_New(AtomicIntHandle, &AtomicIntHandle_Type);
 
     if (handle == NULL)
         goto fail;
@@ -534,7 +534,7 @@ AtomicInt_GetHandle(AtomicInt *self)
     if (AtomicIntHandle_init((AtomicIntHandle *) handle, args, NULL) < 0)
         goto fail;
 
-    return handle;
+    return (PyObject *) handle;
 
     fail:
     return NULL;

--- a/src/cereggii/atomic_int/atomic_int.c
+++ b/src/cereggii/atomic_int/atomic_int.c
@@ -144,7 +144,6 @@ AtomicInt_init(AtomicInt *self, PyObject *args, PyObject *kwargs)
     return 0;
 
     fail:
-    Py_XDECREF(py_integer);
     return -1;
 }
 

--- a/src/cereggii/atomic_int/atomic_int.c
+++ b/src/cereggii/atomic_int/atomic_int.c
@@ -144,7 +144,7 @@ AtomicInt_init(AtomicInt *self, PyObject *args, PyObject *kwargs)
     return 0;
 
     fail:
-    Py_XDECREF(py_integer);
+//    Py_XDECREF(py_integer);
     return -1;
 }
 
@@ -991,12 +991,12 @@ AtomicInt_InplacePower_internal(AtomicInt *self, PyObject *other, PyObject *mod,
     if (do_refcount)
         Py_XINCREF(self);
 
-    Py_DECREF(py_current);
-    Py_DECREF(py_updated);
+//    Py_DECREF(py_current);
+//    Py_DECREF(py_updated);
     return (PyObject *) self;
     fail:
-    Py_XDECREF(py_current);
-    Py_XDECREF(py_updated);
+//    Py_XDECREF(py_current);
+//    Py_XDECREF(py_updated);
     return NULL;
 }
 

--- a/src/cereggii/atomic_int/atomic_int.c
+++ b/src/cereggii/atomic_int/atomic_int.c
@@ -144,7 +144,7 @@ AtomicInt_init(AtomicInt *self, PyObject *args, PyObject *kwargs)
     return 0;
 
     fail:
-//    Py_XDECREF(py_integer);
+    Py_XDECREF(py_integer);
     return -1;
 }
 
@@ -991,12 +991,12 @@ AtomicInt_InplacePower_internal(AtomicInt *self, PyObject *other, PyObject *mod,
     if (do_refcount)
         Py_XINCREF(self);
 
-//    Py_DECREF(py_current);
-//    Py_DECREF(py_updated);
+    Py_DECREF(py_current);
+    Py_DECREF(py_updated);
     return (PyObject *) self;
     fail:
-//    Py_XDECREF(py_current);
-//    Py_XDECREF(py_updated);
+    Py_XDECREF(py_current);
+    Py_XDECREF(py_updated);
     return NULL;
 }
 

--- a/src/cereggii/atomic_int/handle.c
+++ b/src/cereggii/atomic_int/handle.c
@@ -5,16 +5,6 @@
 #include "atomic_int.h"
 #include "atomic_int_internal.h"
 
-
-PyObject *
-AtomicIntHandle_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwargs))
-{
-    AtomicIntHandle *self;
-    self = (AtomicIntHandle *) type->tp_alloc(type, 0);
-
-    return (PyObject *) self;
-}
-
 int
 AtomicIntHandle_init(AtomicIntHandle *self, PyObject *args, PyObject *Py_UNUSED(kwargs))
 {

--- a/src/cereggii/atomic_int/handle.c
+++ b/src/cereggii/atomic_int/handle.c
@@ -25,14 +25,14 @@ AtomicIntHandle_init(AtomicIntHandle *self, PyObject *args, PyObject *Py_UNUSED(
     return 0;
 
     fail:
-//    Py_XDECREF(integer);
+    Py_XDECREF(integer);
     return -1;
 }
 
 void
 AtomicIntHandle_dealloc(AtomicIntHandle *self)
 {
-//    Py_XDECREF(self->integer);
+    Py_XDECREF(self->integer);
     Py_TYPE(self)->tp_free((PyObject *) self);
 
 //    CereggiiAtomic_FenceRelease();

--- a/src/cereggii/atomic_int/handle.c
+++ b/src/cereggii/atomic_int/handle.c
@@ -25,14 +25,14 @@ AtomicIntHandle_init(AtomicIntHandle *self, PyObject *args, PyObject *Py_UNUSED(
     return 0;
 
     fail:
-    Py_XDECREF(integer);
+//    Py_XDECREF(integer);
     return -1;
 }
 
 void
 AtomicIntHandle_dealloc(AtomicIntHandle *self)
 {
-    Py_XDECREF(self->integer);
+//    Py_XDECREF(self->integer);
     Py_TYPE(self)->tp_free((PyObject *) self);
 
 //    CereggiiAtomic_FenceRelease();

--- a/src/cereggii/atomic_ref.c
+++ b/src/cereggii/atomic_ref.c
@@ -30,6 +30,7 @@ _Py_TryIncRefShared(PyObject *op)
     }
 #else
     Py_INCREF(op);
+    return 1;
 #endif
 }
 

--- a/src/cereggii/atomic_ref.c
+++ b/src/cereggii/atomic_ref.c
@@ -46,7 +46,7 @@ AtomicRef_init(AtomicRef *self, PyObject *args, PyObject *Py_UNUSED(kwargs))
     return 0;
 
     fail:
-//    Py_XDECREF(reference);
+    Py_XDECREF(reference);
     return -1;
 }
 
@@ -101,12 +101,12 @@ AtomicRef_Set(AtomicRef *self, PyObject *reference)
     PyObject *current_reference;
     current_reference = AtomicRef_Get(self);
     while (!CereggiiAtomic_CompareExchangePtr((void **) &self->reference, current_reference, reference)) {
-//        Py_DECREF(current_reference);
+        Py_DECREF(current_reference);
         current_reference = AtomicRef_Get(self);
     }
 
-//    Py_DECREF(current_reference);  // decrement for the AtomicRef_Get
-//    Py_DECREF(current_reference);  // decrement because not holding it anymore
+    Py_DECREF(current_reference);  // decrement for the AtomicRef_Get
+    Py_DECREF(current_reference);  // decrement because not holding it anymore
     Py_RETURN_NONE;
 }
 
@@ -124,10 +124,10 @@ AtomicRef_CompareAndSet(AtomicRef *self, PyObject *expected, PyObject *new)
 #endif
     int retval = CereggiiAtomic_CompareExchangePtr((void **) &self->reference, expected, new);
     if (retval) {
-//        Py_DECREF(expected);
+        Py_DECREF(expected);
         return 1;
     } else {
-//        Py_DECREF(new);
+        Py_DECREF(new);
         return 0;
     }
 }

--- a/src/cereggii/atomic_ref.c
+++ b/src/cereggii/atomic_ref.c
@@ -46,7 +46,7 @@ AtomicRef_init(AtomicRef *self, PyObject *args, PyObject *Py_UNUSED(kwargs))
     return 0;
 
     fail:
-    Py_XDECREF(reference);
+//    Py_XDECREF(reference);
     return -1;
 }
 
@@ -101,12 +101,12 @@ AtomicRef_Set(AtomicRef *self, PyObject *reference)
     PyObject *current_reference;
     current_reference = AtomicRef_Get(self);
     while (!CereggiiAtomic_CompareExchangePtr((void **) &self->reference, current_reference, reference)) {
-        Py_DECREF(current_reference);
+//        Py_DECREF(current_reference);
         current_reference = AtomicRef_Get(self);
     }
 
-    Py_DECREF(current_reference);  // decrement for the AtomicRef_Get
-    Py_DECREF(current_reference);  // decrement because not holding it anymore
+//    Py_DECREF(current_reference);  // decrement for the AtomicRef_Get
+//    Py_DECREF(current_reference);  // decrement because not holding it anymore
     Py_RETURN_NONE;
 }
 
@@ -124,10 +124,10 @@ AtomicRef_CompareAndSet(AtomicRef *self, PyObject *expected, PyObject *new)
 #endif
     int retval = CereggiiAtomic_CompareExchangePtr((void **) &self->reference, expected, new);
     if (retval) {
-        Py_DECREF(expected);
+//        Py_DECREF(expected);
         return 1;
     } else {
-        Py_DECREF(new);
+//        Py_DECREF(new);
         return 0;
     }
 }

--- a/src/cereggii/atomic_ref.c
+++ b/src/cereggii/atomic_ref.c
@@ -8,19 +8,18 @@
 
 
 PyObject *
-AtomicRef_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwds))
+AtomicRef_new(PyTypeObject *Py_UNUSED(type), PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwds))
 {
     AtomicRef *self;
-    self = (AtomicRef *) type->tp_alloc(type, 0);
+    self = PyObject_GC_New(AtomicRef, &AtomicRef_Type);
 
     if (self == NULL)
         return NULL;
 
     self->reference = Py_None;
 
-    if (!PyObject_GC_IsTracked((PyObject *) self)) {
-        PyObject_GC_Track(self);
-    }
+    PyObject_GC_Track(self);
+
     return (PyObject *) self;
 }
 
@@ -51,18 +50,26 @@ AtomicRef_init(AtomicRef *self, PyObject *args, PyObject *Py_UNUSED(kwargs))
     return -1;
 }
 
-void AtomicRef_dealloc(AtomicRef *self)
-{
-    PyObject_GC_UnTrack(self);
-    Py_CLEAR(self->reference);
-    Py_TYPE(self)->tp_free((PyObject *) self);
-}
-
 int
 AtomicRef_traverse(AtomicRef *self, visitproc visit, void *arg)
 {
     Py_VISIT(self->reference);
     return 0;
+}
+
+int
+AtomicRef_clear(AtomicRef *self)
+{
+    Py_CLEAR(self->reference);
+
+    return 0;
+}
+
+void AtomicRef_dealloc(AtomicRef *self)
+{
+    PyObject_GC_UnTrack(self);
+    Py_CLEAR(self->reference);
+    Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
 

--- a/src/cereggii/atomic_ref.c
+++ b/src/cereggii/atomic_ref.c
@@ -10,7 +10,7 @@ static inline int
 _Py_TryIncRefShared(PyObject *op)
 {
     // I know, I know
-
+#ifdef Py_GIL_DISABLED
     // https://github.com/python/cpython/blob/9e551f9b351440ebae79e07a02d0e4a1b61d139e/Include/internal/pycore_object.h#L499
     Py_ssize_t shared = op->ob_ref_shared;
     for (;;) {
@@ -28,11 +28,15 @@ _Py_TryIncRefShared(PyObject *op)
         }
         return 0;  // are they actually using some other function?
     }
+#else
+    Py_INCREF(op);
+#endif
 }
 
 static inline void
 _PyObject_SetMaybeWeakref(PyObject *op)
 {
+#ifdef Py_GIL_DISABLED
     // https://github.com/python/cpython/blob/9e551f9b351440ebae79e07a02d0e4a1b61d139e/Include/internal/pycore_object.h#L608
     for (;;) {
         Py_ssize_t shared = CereggiiAtomic_LoadSsize((const Py_ssize_t *) &op->ob_ref_shared);
@@ -45,6 +49,7 @@ _PyObject_SetMaybeWeakref(PyObject *op)
             return;
         }
     }
+#endif
 }
 
 

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -252,9 +252,10 @@ PyTypeObject AtomicDictMeta_Type = {
     .tp_name = "cereggii._AtomicDictMeta",
     .tp_basicsize = sizeof(AtomicDict_Meta),
     .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = PyType_GenericNew,
     .tp_dealloc = (destructor) AtomicDictMeta_dealloc,
+    .tp_traverse = (traverseproc) AtomicDictMeta_traverse,
 };
 
 PyTypeObject AtomicDictBlock_Type = {
@@ -262,9 +263,10 @@ PyTypeObject AtomicDictBlock_Type = {
     .tp_name = "cereggii._AtomicDictBlock",
     .tp_basicsize = sizeof(AtomicDict_Block),
     .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = PyType_GenericNew,
     .tp_dealloc = (destructor) AtomicDictBlock_dealloc,
+    .tp_traverse = (traverseproc) AtomicDictBlock_traverse,
 };
 
 PyTypeObject AtomicDictAccessorStorage_Type = {

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -393,55 +393,55 @@ PyInit__cereggii(void)
 #endif
 
     if (PyModule_AddObjectRef(m, "NOT_FOUND", NOT_FOUND) < 0) {
-        Py_DECREF(NOT_FOUND);
+//        Py_DECREF(NOT_FOUND);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "ANY", ANY) < 0) {
-        Py_DECREF(ANY);
+//        Py_DECREF(ANY);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
-        Py_DECREF(EXPECTATION_FAILED);
+//        Py_DECREF(EXPECTATION_FAILED);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
-        Py_DECREF(Cereggii_ExpectationFailed);
+//        Py_DECREF(Cereggii_ExpectationFailed);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
-        Py_DECREF(&AtomicDict_Type);
+//        Py_DECREF(&AtomicDict_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
-        Py_DECREF(&AtomicEvent_Type);
+//        Py_DECREF(&AtomicEvent_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
-        Py_DECREF(&AtomicRef_Type);
+//        Py_DECREF(&AtomicRef_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
-        Py_DECREF(&AtomicInt_Type);
+//        Py_DECREF(&AtomicInt_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
-        Py_DECREF(&AtomicIntHandle_Type);
+//        Py_DECREF(&AtomicIntHandle_Type);
         goto fail;
     }
 
     return m;
     fail:
-    Py_DECREF(m);
-    Py_XDECREF(NOT_FOUND);
-    Py_XDECREF(ANY);
-    Py_XDECREF(EXPECTATION_FAILED);
+//    Py_DECREF(m);
+//    Py_XDECREF(NOT_FOUND);
+//    Py_XDECREF(ANY);
+//    Py_XDECREF(EXPECTATION_FAILED);
     return NULL;
 }

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -90,7 +90,7 @@ PyTypeObject AtomicInt_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     .tp_basicsize = sizeof(AtomicInt),
     .tp_itemsize = 0,
-    .tp_new = AtomicInt_new,
+    .tp_new = PyType_GenericNew,
     .tp_init = (initproc) AtomicInt_init,
     .tp_dealloc = (destructor) AtomicInt_dealloc,
     .tp_methods = AtomicInt_methods,
@@ -178,7 +178,7 @@ PyTypeObject AtomicIntHandle_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     .tp_basicsize = sizeof(AtomicIntHandle),
     .tp_itemsize = 0,
-    .tp_new = AtomicIntHandle_new,
+    .tp_new = PyType_GenericNew,
     .tp_init = (initproc) AtomicIntHandle_init,
     .tp_dealloc = (destructor) AtomicIntHandle_dealloc,
     .tp_methods = AtomicIntHandle_methods,
@@ -206,8 +206,9 @@ PyTypeObject AtomicRef_Type = {
     .tp_itemsize = 0,
     .tp_new = AtomicRef_new,
     .tp_init = (initproc) AtomicRef_init,
-    .tp_dealloc = (destructor) AtomicRef_dealloc,
     .tp_traverse = (traverseproc) AtomicRef_traverse,
+    .tp_clear = (inquiry) AtomicRef_clear,
+    .tp_dealloc = (destructor) AtomicRef_dealloc,
     .tp_methods = AtomicRef_methods,
 };
 
@@ -232,7 +233,7 @@ static PyMappingMethods AtomicDict_mapping_methods = {
     .mp_ass_subscript = (objobjargproc) AtomicDict_SetItem,
 };
 
-static PyTypeObject AtomicDict_Type = {
+PyTypeObject AtomicDict_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicDict",
     .tp_doc = PyDoc_STR("A thread-safe dictionary (hashmap), that's almost-lock-free™."),
@@ -240,8 +241,9 @@ static PyTypeObject AtomicDict_Type = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = AtomicDict_new,
-    .tp_dealloc = (destructor) AtomicDict_dealloc,
     .tp_traverse = (traverseproc) AtomicDict_traverse,
+    .tp_clear = (inquiry) AtomicDict_clear,
+    .tp_dealloc = (destructor) AtomicDict_dealloc,
     .tp_init = (initproc) AtomicDict_init,
     .tp_methods = AtomicDict_methods,
     .tp_as_mapping = &AtomicDict_mapping_methods,
@@ -254,8 +256,9 @@ PyTypeObject AtomicDictMeta_Type = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = PyType_GenericNew,
-    .tp_dealloc = (destructor) AtomicDictMeta_dealloc,
     .tp_traverse = (traverseproc) AtomicDictMeta_traverse,
+    .tp_clear = (inquiry) AtomicDictMeta_clear,
+    .tp_dealloc = (destructor) AtomicDictMeta_dealloc,
 };
 
 PyTypeObject AtomicDictBlock_Type = {
@@ -265,8 +268,9 @@ PyTypeObject AtomicDictBlock_Type = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = PyType_GenericNew,
-    .tp_dealloc = (destructor) AtomicDictBlock_dealloc,
     .tp_traverse = (traverseproc) AtomicDictBlock_traverse,
+    .tp_clear = (inquiry) AtomicDictBlock_clear,
+    .tp_dealloc = (destructor) AtomicDictBlock_dealloc,
 };
 
 PyTypeObject AtomicDictAccessorStorage_Type = {
@@ -306,7 +310,7 @@ PyTypeObject AtomicEvent_Type = {
     .tp_basicsize = sizeof(AtomicEvent),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT,
-    .tp_new = AtomicEvent_new,
+    .tp_new = PyType_GenericNew,
     .tp_dealloc = (destructor) AtomicEvent_dealloc,
     .tp_init = (initproc) AtomicEvent_init,
     .tp_methods = AtomicEvent_methods,
@@ -326,7 +330,7 @@ PyTypeObject CereggiiConstant_Type = {
     .tp_basicsize = sizeof(CereggiiConstant),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT,
-    .tp_new = NULL,
+    .tp_new = PyType_GenericNew,
     .tp_repr = (reprfunc) CereggiiConstant_Repr,
 };
 

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -341,22 +341,22 @@ PyInit__cereggii(void)
 {
     PyObject *m;
 
-    if (PyType_Ready(&CereggiiConstant_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDict_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicEvent_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicRef_Type) < 0)
-        return NULL;
+//    if (PyType_Ready(&CereggiiConstant_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDict_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicEvent_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicRef_Type) < 0)
+//        return NULL;
     if (PyType_Ready(&AtomicInt_Type) < 0)
         return NULL;
     if (PyType_Ready(&AtomicIntHandle_Type) < 0)
@@ -370,56 +370,56 @@ PyInit__cereggii(void)
     PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
-    NOT_FOUND = CereggiiConstant_New("NOT_FOUND");
-    if (NOT_FOUND == NULL)
-        goto fail;
-    if (PyModule_AddObject(m, "NOT_FOUND", NOT_FOUND) < 0) {
-        Py_DECREF(NOT_FOUND);
-        goto fail;
-    }
-
-    ANY = CereggiiConstant_New("ANY");
-    if (ANY == NULL)
-        goto fail;
-    if (PyModule_AddObject(m, "ANY", ANY) < 0) {
-        Py_DECREF(ANY);
-        goto fail;
-    }
-
-    EXPECTATION_FAILED = CereggiiConstant_New("EXPECTATION_FAILED");
-    if (EXPECTATION_FAILED == NULL)
-        goto fail;
-    if (PyModule_AddObject(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
-        Py_DECREF(EXPECTATION_FAILED);
-        goto fail;
-    }
-
-    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
-    if (Cereggii_ExpectationFailed == NULL)
-        goto fail;
-    Py_INCREF(Cereggii_ExpectationFailed);
-    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
-        Py_DECREF(Cereggii_ExpectationFailed);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicDict_Type);
-    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
-        Py_DECREF(&AtomicDict_Type);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicEvent_Type);
-    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
-        Py_DECREF(&AtomicEvent_Type);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicRef_Type);
-    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
-        Py_DECREF(&AtomicRef_Type);
-        goto fail;
-    }
+//    NOT_FOUND = CereggiiConstant_New("NOT_FOUND");
+//    if (NOT_FOUND == NULL)
+//        goto fail;
+//    if (PyModule_AddObject(m, "NOT_FOUND", NOT_FOUND) < 0) {
+//        Py_DECREF(NOT_FOUND);
+//        goto fail;
+//    }
+//
+//    ANY = CereggiiConstant_New("ANY");
+//    if (ANY == NULL)
+//        goto fail;
+//    if (PyModule_AddObject(m, "ANY", ANY) < 0) {
+//        Py_DECREF(ANY);
+//        goto fail;
+//    }
+//
+//    EXPECTATION_FAILED = CereggiiConstant_New("EXPECTATION_FAILED");
+//    if (EXPECTATION_FAILED == NULL)
+//        goto fail;
+//    if (PyModule_AddObject(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
+//        Py_DECREF(EXPECTATION_FAILED);
+//        goto fail;
+//    }
+//
+//    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
+//    if (Cereggii_ExpectationFailed == NULL)
+//        goto fail;
+//    Py_INCREF(Cereggii_ExpectationFailed);
+//    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
+//        Py_DECREF(Cereggii_ExpectationFailed);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicDict_Type);
+//    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
+//        Py_DECREF(&AtomicDict_Type);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicEvent_Type);
+//    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
+//        Py_DECREF(&AtomicEvent_Type);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicRef_Type);
+//    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
+//        Py_DECREF(&AtomicRef_Type);
+//        goto fail;
+//    }
 
     Py_INCREF(&AtomicInt_Type);
     if (PyModule_AddObject(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -362,6 +362,22 @@ PyInit__cereggii(void)
     if (PyType_Ready(&AtomicIntHandle_Type) < 0)
         return NULL;
 
+    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
+    if (Cereggii_ExpectationFailed == NULL)
+        return NULL;
+
+    NOT_FOUND = CereggiiConstant_New("NOT_FOUND");
+    if (NOT_FOUND == NULL)
+        return NULL;
+
+    ANY = CereggiiConstant_New("ANY");
+    if (ANY == NULL)
+        return NULL;
+
+    EXPECTATION_FAILED = CereggiiConstant_New("EXPECTATION_FAILED");
+    if (EXPECTATION_FAILED == NULL)
+        return NULL;
+
     m = PyModule_Create(&cereggii_module);
     if (m == NULL)
         return NULL;
@@ -370,33 +386,21 @@ PyInit__cereggii(void)
     PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
-    NOT_FOUND = CereggiiConstant_New("NOT_FOUND");
-    if (NOT_FOUND == NULL)
-        goto fail;
     if (PyModule_AddObjectRef(m, "NOT_FOUND", NOT_FOUND) < 0) {
         Py_DECREF(NOT_FOUND);
         goto fail;
     }
 
-    ANY = CereggiiConstant_New("ANY");
-    if (ANY == NULL)
-        goto fail;
     if (PyModule_AddObjectRef(m, "ANY", ANY) < 0) {
         Py_DECREF(ANY);
         goto fail;
     }
 
-    EXPECTATION_FAILED = CereggiiConstant_New("EXPECTATION_FAILED");
-    if (EXPECTATION_FAILED == NULL)
-        goto fail;
     if (PyModule_AddObjectRef(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
         Py_DECREF(EXPECTATION_FAILED);
         goto fail;
     }
 
-    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
-    if (Cereggii_ExpectationFailed == NULL)
-        goto fail;
     if (PyModule_AddObjectRef(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
         Py_DECREF(Cereggii_ExpectationFailed);
         goto fail;

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -345,7 +345,7 @@ static PyModuleDef cereggii_module = {
 __attribute__((unused)) PyMODINIT_FUNC
 PyInit__cereggii(void)
 {
-    PyObject *m;
+    PyObject *m = NULL;
 
     if (PyType_Ready(&CereggiiConstant_Type) < 0)
         return NULL;
@@ -392,54 +392,45 @@ PyInit__cereggii(void)
     PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
-    if (PyModule_AddObjectRef(m, "NOT_FOUND", NOT_FOUND) < 0) {
-        Py_DECREF(NOT_FOUND);
+    if (PyModule_AddObjectRef(m, "NOT_FOUND", NOT_FOUND) < 0)
         goto fail;
-    }
+    Py_DECREF(NOT_FOUND);
 
-    if (PyModule_AddObjectRef(m, "ANY", ANY) < 0) {
-        Py_DECREF(ANY);
+    if (PyModule_AddObjectRef(m, "ANY", ANY) < 0)
         goto fail;
-    }
+    Py_DECREF(ANY);
 
-    if (PyModule_AddObjectRef(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
-        Py_DECREF(EXPECTATION_FAILED);
+    if (PyModule_AddObjectRef(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0)
         goto fail;
-    }
+    Py_DECREF(EXPECTATION_FAILED);
 
-    if (PyModule_AddObjectRef(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
-        Py_DECREF(Cereggii_ExpectationFailed);
+    if (PyModule_AddObjectRef(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0)
         goto fail;
-    }
+    Py_DECREF(Cereggii_ExpectationFailed);
 
-    if (PyModule_AddObjectRef(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
-        Py_DECREF(&AtomicDict_Type);
+    if (PyModule_AddObjectRef(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0)
         goto fail;
-    }
+    Py_DECREF(&AtomicDict_Type);
 
-    if (PyModule_AddObjectRef(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
-        Py_DECREF(&AtomicEvent_Type);
+    if (PyModule_AddObjectRef(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0)
         goto fail;
-    }
+    Py_DECREF(&AtomicEvent_Type);
 
-    if (PyModule_AddObjectRef(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
-        Py_DECREF(&AtomicRef_Type);
+    if (PyModule_AddObjectRef(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0)
         goto fail;
-    }
+    Py_DECREF(&AtomicRef_Type);
 
-    if (PyModule_AddObjectRef(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
-        Py_DECREF(&AtomicInt_Type);
+    if (PyModule_AddObjectRef(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0)
         goto fail;
-    }
+    Py_DECREF(&AtomicInt_Type);
 
-    if (PyModule_AddObjectRef(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
-        Py_DECREF(&AtomicIntHandle_Type);
+    if (PyModule_AddObjectRef(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0)
         goto fail;
-    }
+    Py_DECREF(&AtomicIntHandle_Type);
 
     return m;
     fail:
-    Py_DECREF(m);
+    Py_XDECREF(m);
     Py_XDECREF(NOT_FOUND);
     Py_XDECREF(ANY);
     Py_XDECREF(EXPECTATION_FAILED);

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -341,24 +341,34 @@ PyInit__cereggii(void)
 {
     PyObject *m;
 
+    assert(CereggiiConstant_Type.tp_name);
     if (PyType_Ready(&CereggiiConstant_Type) < 0)
         return NULL;
+    assert(AtomicDict_Type.tp_name);
     if (PyType_Ready(&AtomicDict_Type) < 0)
         return NULL;
+    assert(AtomicDictMeta_Type.tp_name);
     if (PyType_Ready(&AtomicDictMeta_Type) < 0)
         return NULL;
+    assert(AtomicDictBlock_Type.tp_name);
     if (PyType_Ready(&AtomicDictBlock_Type) < 0)
         return NULL;
+    assert(AtomicDictAccessorStorage_Type.tp_name);
     if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
         return NULL;
+    assert(AtomicDictFastIterator_Type.tp_name);
     if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
         return NULL;
+    assert(AtomicEvent_Type.tp_name);
     if (PyType_Ready(&AtomicEvent_Type) < 0)
         return NULL;
+    assert(AtomicRef_Type.tp_name);
     if (PyType_Ready(&AtomicRef_Type) < 0)
         return NULL;
+    assert(AtomicInt_Type.tp_name);
     if (PyType_Ready(&AtomicInt_Type) < 0)
         return NULL;
+    assert(AtomicIntHandle_Type.tp_name);
     if (PyType_Ready(&AtomicIntHandle_Type) < 0)
         return NULL;
 
@@ -397,37 +407,31 @@ PyInit__cereggii(void)
     Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
     if (Cereggii_ExpectationFailed == NULL)
         goto fail;
-    Py_INCREF(Cereggii_ExpectationFailed);
     if (PyModule_AddObjectRef(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
         Py_DECREF(Cereggii_ExpectationFailed);
         goto fail;
     }
 
-    Py_INCREF(&AtomicDict_Type);
     if (PyModule_AddObjectRef(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
         Py_DECREF(&AtomicDict_Type);
         goto fail;
     }
 
-    Py_INCREF(&AtomicEvent_Type);
     if (PyModule_AddObjectRef(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
         Py_DECREF(&AtomicEvent_Type);
         goto fail;
     }
 
-    Py_INCREF(&AtomicRef_Type);
     if (PyModule_AddObjectRef(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
         Py_DECREF(&AtomicRef_Type);
         goto fail;
     }
 
-    Py_INCREF(&AtomicInt_Type);
     if (PyModule_AddObjectRef(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
         Py_DECREF(&AtomicInt_Type);
         goto fail;
     }
 
-    Py_INCREF(&AtomicIntHandle_Type);
     if (PyModule_AddObjectRef(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
         Py_DECREF(&AtomicIntHandle_Type);
         goto fail;

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -343,24 +343,24 @@ PyInit__cereggii(void)
 
     if (PyType_Ready(&CereggiiConstant_Type) < 0)
         return NULL;
-    if (PyType_Ready(&AtomicDict_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicEvent_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicRef_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicInt_Type) < 0)
-        return NULL;
-    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
-        return NULL;
+//    if (PyType_Ready(&AtomicDict_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicEvent_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicRef_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicInt_Type) < 0)
+//        return NULL;
+//    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
+//        return NULL;
 
     m = PyModule_Create(&cereggii_module);
     if (m == NULL)
@@ -394,44 +394,44 @@ PyInit__cereggii(void)
         goto fail;
     }
 
-    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
-    if (Cereggii_ExpectationFailed == NULL)
-        goto fail;
-    Py_INCREF(Cereggii_ExpectationFailed);
-    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
-        Py_DECREF(Cereggii_ExpectationFailed);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicDict_Type);
-    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
-        Py_DECREF(&AtomicDict_Type);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicEvent_Type);
-    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
-        Py_DECREF(&AtomicEvent_Type);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicRef_Type);
-    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
-        Py_DECREF(&AtomicRef_Type);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicInt_Type);
-    if (PyModule_AddObject(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
-        Py_DECREF(&AtomicInt_Type);
-        goto fail;
-    }
-
-    Py_INCREF(&AtomicIntHandle_Type);
-    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
-        Py_DECREF(&AtomicIntHandle_Type);
-        goto fail;
-    }
+//    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
+//    if (Cereggii_ExpectationFailed == NULL)
+//        goto fail;
+//    Py_INCREF(Cereggii_ExpectationFailed);
+//    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
+//        Py_DECREF(Cereggii_ExpectationFailed);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicDict_Type);
+//    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
+//        Py_DECREF(&AtomicDict_Type);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicEvent_Type);
+//    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
+//        Py_DECREF(&AtomicEvent_Type);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicRef_Type);
+//    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
+//        Py_DECREF(&AtomicRef_Type);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicInt_Type);
+//    if (PyModule_AddObject(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
+//        Py_DECREF(&AtomicInt_Type);
+//        goto fail;
+//    }
+//
+//    Py_INCREF(&AtomicIntHandle_Type);
+//    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
+//        Py_DECREF(&AtomicIntHandle_Type);
+//        goto fail;
+//    }
 
     return m;
     fail:

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -84,7 +84,7 @@ static PyNumberMethods AtomicInt_as_number = {
 };
 
 PyTypeObject AtomicInt_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicInt",
     .tp_doc = PyDoc_STR("An int that may be updated atomically."),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
@@ -172,7 +172,7 @@ static PyNumberMethods AtomicIntHandle_as_number = {
 };
 
 PyTypeObject AtomicIntHandle_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicIntHandle",
     .tp_doc = PyDoc_STR("An immutable handle for referencing an AtomicInt."),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
@@ -198,7 +198,7 @@ static PyMethodDef AtomicRef_methods[] = {
 };
 
 PyTypeObject AtomicRef_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicRef",
     .tp_doc = PyDoc_STR("An object reference that may be updated atomically."),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
@@ -233,7 +233,7 @@ static PyMappingMethods AtomicDict_mapping_methods = {
 };
 
 static PyTypeObject AtomicDict_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicDict",
     .tp_doc = PyDoc_STR("A thread-safe dictionary (hashmap), that's almost-lock-free™."),
     .tp_basicsize = sizeof(AtomicDict),
@@ -248,7 +248,7 @@ static PyTypeObject AtomicDict_Type = {
 };
 
 PyTypeObject AtomicDictMeta_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictMeta",
     .tp_basicsize = sizeof(AtomicDict_Meta),
     .tp_itemsize = 0,
@@ -258,7 +258,7 @@ PyTypeObject AtomicDictMeta_Type = {
 };
 
 PyTypeObject AtomicDictBlock_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictBlock",
     .tp_basicsize = sizeof(AtomicDict_Block),
     .tp_itemsize = 0,
@@ -268,7 +268,7 @@ PyTypeObject AtomicDictBlock_Type = {
 };
 
 PyTypeObject AtomicDictAccessorStorage_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictAccessorStorage",
     .tp_basicsize = sizeof(AtomicDict_AccessorStorage),
     .tp_itemsize = 0,
@@ -278,7 +278,7 @@ PyTypeObject AtomicDictAccessorStorage_Type = {
 };
 
 PyTypeObject AtomicDictFastIterator_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictFastIterator",
     .tp_basicsize = sizeof(AtomicDict_FastIterator),
     .tp_itemsize = 0,
@@ -298,7 +298,7 @@ static PyMethodDef AtomicEvent_methods[] = {
 };
 
 PyTypeObject AtomicEvent_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicEvent",
     .tp_doc = PyDoc_STR("An atomic event based on pthread's condition locks."),
     .tp_basicsize = sizeof(AtomicEvent),
@@ -318,7 +318,7 @@ PyObject *EXPECTATION_FAILED = NULL;
 PyObject *Cereggii_ExpectationFailed = NULL;
 
 PyTypeObject CereggiiConstant_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.Constant",
     .tp_doc = PyDoc_STR("A constant value."),
     .tp_basicsize = sizeof(CereggiiConstant),
@@ -330,7 +330,7 @@ PyTypeObject CereggiiConstant_Type = {
 
 
 static PyModuleDef cereggii_module = {
-    PyModuleDef_HEAD_INIT,
+    .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_cereggii",
     .m_doc = NULL,
     .m_size = -1,

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -373,7 +373,7 @@ PyInit__cereggii(void)
     NOT_FOUND = CereggiiConstant_New("NOT_FOUND");
     if (NOT_FOUND == NULL)
         goto fail;
-    if (PyModule_AddObject(m, "NOT_FOUND", NOT_FOUND) < 0) {
+    if (PyModule_AddObjectRef(m, "NOT_FOUND", NOT_FOUND) < 0) {
         Py_DECREF(NOT_FOUND);
         goto fail;
     }
@@ -381,7 +381,7 @@ PyInit__cereggii(void)
     ANY = CereggiiConstant_New("ANY");
     if (ANY == NULL)
         goto fail;
-    if (PyModule_AddObject(m, "ANY", ANY) < 0) {
+    if (PyModule_AddObjectRef(m, "ANY", ANY) < 0) {
         Py_DECREF(ANY);
         goto fail;
     }
@@ -389,7 +389,7 @@ PyInit__cereggii(void)
     EXPECTATION_FAILED = CereggiiConstant_New("EXPECTATION_FAILED");
     if (EXPECTATION_FAILED == NULL)
         goto fail;
-    if (PyModule_AddObject(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
+    if (PyModule_AddObjectRef(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
         Py_DECREF(EXPECTATION_FAILED);
         goto fail;
     }
@@ -398,37 +398,37 @@ PyInit__cereggii(void)
     if (Cereggii_ExpectationFailed == NULL)
         goto fail;
     Py_INCREF(Cereggii_ExpectationFailed);
-    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
+    if (PyModule_AddObjectRef(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
         Py_DECREF(Cereggii_ExpectationFailed);
         goto fail;
     }
 
     Py_INCREF(&AtomicDict_Type);
-    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
+    if (PyModule_AddObjectRef(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
         Py_DECREF(&AtomicDict_Type);
         goto fail;
     }
 
     Py_INCREF(&AtomicEvent_Type);
-    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
+    if (PyModule_AddObjectRef(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
         Py_DECREF(&AtomicEvent_Type);
         goto fail;
     }
 
     Py_INCREF(&AtomicRef_Type);
-    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
+    if (PyModule_AddObjectRef(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
         Py_DECREF(&AtomicRef_Type);
         goto fail;
     }
 
     Py_INCREF(&AtomicInt_Type);
-    if (PyModule_AddObject(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
+    if (PyModule_AddObjectRef(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
         Py_DECREF(&AtomicInt_Type);
         goto fail;
     }
 
     Py_INCREF(&AtomicIntHandle_Type);
-    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
+    if (PyModule_AddObjectRef(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
         Py_DECREF(&AtomicIntHandle_Type);
         goto fail;
     }

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -393,55 +393,55 @@ PyInit__cereggii(void)
 #endif
 
     if (PyModule_AddObjectRef(m, "NOT_FOUND", NOT_FOUND) < 0) {
-//        Py_DECREF(NOT_FOUND);
+        Py_DECREF(NOT_FOUND);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "ANY", ANY) < 0) {
-//        Py_DECREF(ANY);
+        Py_DECREF(ANY);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
-//        Py_DECREF(EXPECTATION_FAILED);
+        Py_DECREF(EXPECTATION_FAILED);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
-//        Py_DECREF(Cereggii_ExpectationFailed);
+        Py_DECREF(Cereggii_ExpectationFailed);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
-//        Py_DECREF(&AtomicDict_Type);
+        Py_DECREF(&AtomicDict_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
-//        Py_DECREF(&AtomicEvent_Type);
+        Py_DECREF(&AtomicEvent_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
-//        Py_DECREF(&AtomicRef_Type);
+        Py_DECREF(&AtomicRef_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
-//        Py_DECREF(&AtomicInt_Type);
+        Py_DECREF(&AtomicInt_Type);
         goto fail;
     }
 
     if (PyModule_AddObjectRef(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
-//        Py_DECREF(&AtomicIntHandle_Type);
+        Py_DECREF(&AtomicIntHandle_Type);
         goto fail;
     }
 
     return m;
     fail:
-//    Py_DECREF(m);
-//    Py_XDECREF(NOT_FOUND);
-//    Py_XDECREF(ANY);
-//    Py_XDECREF(EXPECTATION_FAILED);
+    Py_DECREF(m);
+    Py_XDECREF(NOT_FOUND);
+    Py_XDECREF(ANY);
+    Py_XDECREF(EXPECTATION_FAILED);
     return NULL;
 }

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -341,26 +341,26 @@ PyInit__cereggii(void)
 {
     PyObject *m;
 
-//    if (PyType_Ready(&CereggiiConstant_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDict_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicEvent_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicRef_Type) < 0)
-//        return NULL;
+    if (PyType_Ready(&CereggiiConstant_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDict_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicEvent_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicRef_Type) < 0)
+        return NULL;
     if (PyType_Ready(&AtomicInt_Type) < 0)
         return NULL;
-//    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
-//        return NULL;
+    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
+        return NULL;
 
     m = PyModule_Create(&cereggii_module);
     if (m == NULL)
@@ -370,56 +370,56 @@ PyInit__cereggii(void)
     PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif
 
-//    NOT_FOUND = CereggiiConstant_New("NOT_FOUND");
-//    if (NOT_FOUND == NULL)
-//        goto fail;
-//    if (PyModule_AddObject(m, "NOT_FOUND", NOT_FOUND) < 0) {
-//        Py_DECREF(NOT_FOUND);
-//        goto fail;
-//    }
-//
-//    ANY = CereggiiConstant_New("ANY");
-//    if (ANY == NULL)
-//        goto fail;
-//    if (PyModule_AddObject(m, "ANY", ANY) < 0) {
-//        Py_DECREF(ANY);
-//        goto fail;
-//    }
-//
-//    EXPECTATION_FAILED = CereggiiConstant_New("EXPECTATION_FAILED");
-//    if (EXPECTATION_FAILED == NULL)
-//        goto fail;
-//    if (PyModule_AddObject(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
-//        Py_DECREF(EXPECTATION_FAILED);
-//        goto fail;
-//    }
-//
-//    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
-//    if (Cereggii_ExpectationFailed == NULL)
-//        goto fail;
-//    Py_INCREF(Cereggii_ExpectationFailed);
-//    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
-//        Py_DECREF(Cereggii_ExpectationFailed);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicDict_Type);
-//    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
-//        Py_DECREF(&AtomicDict_Type);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicEvent_Type);
-//    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
-//        Py_DECREF(&AtomicEvent_Type);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicRef_Type);
-//    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
-//        Py_DECREF(&AtomicRef_Type);
-//        goto fail;
-//    }
+    NOT_FOUND = CereggiiConstant_New("NOT_FOUND");
+    if (NOT_FOUND == NULL)
+        goto fail;
+    if (PyModule_AddObject(m, "NOT_FOUND", NOT_FOUND) < 0) {
+        Py_DECREF(NOT_FOUND);
+        goto fail;
+    }
+
+    ANY = CereggiiConstant_New("ANY");
+    if (ANY == NULL)
+        goto fail;
+    if (PyModule_AddObject(m, "ANY", ANY) < 0) {
+        Py_DECREF(ANY);
+        goto fail;
+    }
+
+    EXPECTATION_FAILED = CereggiiConstant_New("EXPECTATION_FAILED");
+    if (EXPECTATION_FAILED == NULL)
+        goto fail;
+    if (PyModule_AddObject(m, "EXPECTATION_FAILED", EXPECTATION_FAILED) < 0) {
+        Py_DECREF(EXPECTATION_FAILED);
+        goto fail;
+    }
+
+    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
+    if (Cereggii_ExpectationFailed == NULL)
+        goto fail;
+    Py_INCREF(Cereggii_ExpectationFailed);
+    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
+        Py_DECREF(Cereggii_ExpectationFailed);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicDict_Type);
+    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
+        Py_DECREF(&AtomicDict_Type);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicEvent_Type);
+    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
+        Py_DECREF(&AtomicEvent_Type);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicRef_Type);
+    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
+        Py_DECREF(&AtomicRef_Type);
+        goto fail;
+    }
 
     Py_INCREF(&AtomicInt_Type);
     if (PyModule_AddObject(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
@@ -427,11 +427,11 @@ PyInit__cereggii(void)
         goto fail;
     }
 
-//    Py_INCREF(&AtomicIntHandle_Type);
-//    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
-//        Py_DECREF(&AtomicIntHandle_Type);
-//        goto fail;
-//    }
+    Py_INCREF(&AtomicIntHandle_Type);
+    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
+        Py_DECREF(&AtomicIntHandle_Type);
+        goto fail;
+    }
 
     return m;
     fail:

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -343,24 +343,24 @@ PyInit__cereggii(void)
 
     if (PyType_Ready(&CereggiiConstant_Type) < 0)
         return NULL;
-//    if (PyType_Ready(&AtomicDict_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicEvent_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicRef_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicInt_Type) < 0)
-//        return NULL;
-//    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
-//        return NULL;
+    if (PyType_Ready(&AtomicDict_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictMeta_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictBlock_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicEvent_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicRef_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicInt_Type) < 0)
+        return NULL;
+    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
+        return NULL;
 
     m = PyModule_Create(&cereggii_module);
     if (m == NULL)
@@ -394,44 +394,44 @@ PyInit__cereggii(void)
         goto fail;
     }
 
-//    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
-//    if (Cereggii_ExpectationFailed == NULL)
-//        goto fail;
-//    Py_INCREF(Cereggii_ExpectationFailed);
-//    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
-//        Py_DECREF(Cereggii_ExpectationFailed);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicDict_Type);
-//    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
-//        Py_DECREF(&AtomicDict_Type);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicEvent_Type);
-//    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
-//        Py_DECREF(&AtomicEvent_Type);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicRef_Type);
-//    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
-//        Py_DECREF(&AtomicRef_Type);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicInt_Type);
-//    if (PyModule_AddObject(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
-//        Py_DECREF(&AtomicInt_Type);
-//        goto fail;
-//    }
-//
-//    Py_INCREF(&AtomicIntHandle_Type);
-//    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
-//        Py_DECREF(&AtomicIntHandle_Type);
-//        goto fail;
-//    }
+    Cereggii_ExpectationFailed = PyErr_NewException("cereggii.ExpectationFailed", NULL, NULL);
+    if (Cereggii_ExpectationFailed == NULL)
+        goto fail;
+    Py_INCREF(Cereggii_ExpectationFailed);
+    if (PyModule_AddObject(m, "ExpectationFailed", Cereggii_ExpectationFailed) < 0) {
+        Py_DECREF(Cereggii_ExpectationFailed);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicDict_Type);
+    if (PyModule_AddObject(m, "AtomicDict", (PyObject *) &AtomicDict_Type) < 0) {
+        Py_DECREF(&AtomicDict_Type);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicEvent_Type);
+    if (PyModule_AddObject(m, "AtomicEvent", (PyObject *) &AtomicEvent_Type) < 0) {
+        Py_DECREF(&AtomicEvent_Type);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicRef_Type);
+    if (PyModule_AddObject(m, "AtomicRef", (PyObject *) &AtomicRef_Type) < 0) {
+        Py_DECREF(&AtomicRef_Type);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicInt_Type);
+    if (PyModule_AddObject(m, "AtomicInt", (PyObject *) &AtomicInt_Type) < 0) {
+        Py_DECREF(&AtomicInt_Type);
+        goto fail;
+    }
+
+    Py_INCREF(&AtomicIntHandle_Type);
+    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
+        Py_DECREF(&AtomicIntHandle_Type);
+        goto fail;
+    }
 
     return m;
     fail:

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -359,8 +359,8 @@ PyInit__cereggii(void)
 //        return NULL;
     if (PyType_Ready(&AtomicInt_Type) < 0)
         return NULL;
-    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
-        return NULL;
+//    if (PyType_Ready(&AtomicIntHandle_Type) < 0)
+//        return NULL;
 
     m = PyModule_Create(&cereggii_module);
     if (m == NULL)
@@ -427,11 +427,11 @@ PyInit__cereggii(void)
         goto fail;
     }
 
-    Py_INCREF(&AtomicIntHandle_Type);
-    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
-        Py_DECREF(&AtomicIntHandle_Type);
-        goto fail;
-    }
+//    Py_INCREF(&AtomicIntHandle_Type);
+//    if (PyModule_AddObject(m, "AtomicIntHandle", (PyObject *) &AtomicIntHandle_Type) < 0) {
+//        Py_DECREF(&AtomicIntHandle_Type);
+//        goto fail;
+//    }
 
     return m;
     fail:

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -437,27 +437,6 @@ PyInit__cereggii(void)
         goto fail;
     }
 
-    assert(CereggiiConstant_Type.tp_name);
-
-    assert(AtomicDict_Type.tp_name);
-
-    assert(AtomicDictMeta_Type.tp_name);
-
-    assert(AtomicDictBlock_Type.tp_name);
-
-    assert(AtomicDictAccessorStorage_Type.tp_name);
-
-    assert(AtomicDictFastIterator_Type.tp_name);
-
-    assert(AtomicEvent_Type.tp_name);
-
-    assert(AtomicRef_Type.tp_name);
-
-    assert(AtomicInt_Type.tp_name);
-
-    assert(AtomicIntHandle_Type.tp_name);
-
-
     return m;
     fail:
     Py_DECREF(m);

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -84,7 +84,7 @@ static PyNumberMethods AtomicInt_as_number = {
 };
 
 PyTypeObject AtomicInt_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicInt",
     .tp_doc = PyDoc_STR("An int that may be updated atomically."),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
@@ -172,7 +172,7 @@ static PyNumberMethods AtomicIntHandle_as_number = {
 };
 
 PyTypeObject AtomicIntHandle_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicIntHandle",
     .tp_doc = PyDoc_STR("An immutable handle for referencing an AtomicInt."),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
@@ -198,7 +198,7 @@ static PyMethodDef AtomicRef_methods[] = {
 };
 
 PyTypeObject AtomicRef_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicRef",
     .tp_doc = PyDoc_STR("An object reference that may be updated atomically."),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
@@ -233,7 +233,7 @@ static PyMappingMethods AtomicDict_mapping_methods = {
 };
 
 static PyTypeObject AtomicDict_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicDict",
     .tp_doc = PyDoc_STR("A thread-safe dictionary (hashmap), that's almost-lock-free™."),
     .tp_basicsize = sizeof(AtomicDict),
@@ -248,7 +248,7 @@ static PyTypeObject AtomicDict_Type = {
 };
 
 PyTypeObject AtomicDictMeta_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictMeta",
     .tp_basicsize = sizeof(AtomicDict_Meta),
     .tp_itemsize = 0,
@@ -258,7 +258,7 @@ PyTypeObject AtomicDictMeta_Type = {
 };
 
 PyTypeObject AtomicDictBlock_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictBlock",
     .tp_basicsize = sizeof(AtomicDict_Block),
     .tp_itemsize = 0,
@@ -268,7 +268,7 @@ PyTypeObject AtomicDictBlock_Type = {
 };
 
 PyTypeObject AtomicDictAccessorStorage_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictAccessorStorage",
     .tp_basicsize = sizeof(AtomicDict_AccessorStorage),
     .tp_itemsize = 0,
@@ -278,7 +278,7 @@ PyTypeObject AtomicDictAccessorStorage_Type = {
 };
 
 PyTypeObject AtomicDictFastIterator_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii._AtomicDictFastIterator",
     .tp_basicsize = sizeof(AtomicDict_FastIterator),
     .tp_itemsize = 0,
@@ -298,7 +298,7 @@ static PyMethodDef AtomicEvent_methods[] = {
 };
 
 PyTypeObject AtomicEvent_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.AtomicEvent",
     .tp_doc = PyDoc_STR("An atomic event based on pthread's condition locks."),
     .tp_basicsize = sizeof(AtomicEvent),
@@ -318,7 +318,7 @@ PyObject *EXPECTATION_FAILED = NULL;
 PyObject *Cereggii_ExpectationFailed = NULL;
 
 PyTypeObject CereggiiConstant_Type = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0)
+    PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "cereggii.Constant",
     .tp_doc = PyDoc_STR("A constant value."),
     .tp_basicsize = sizeof(CereggiiConstant),

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -341,34 +341,24 @@ PyInit__cereggii(void)
 {
     PyObject *m;
 
-    assert(CereggiiConstant_Type.tp_name);
     if (PyType_Ready(&CereggiiConstant_Type) < 0)
         return NULL;
-    assert(AtomicDict_Type.tp_name);
     if (PyType_Ready(&AtomicDict_Type) < 0)
         return NULL;
-    assert(AtomicDictMeta_Type.tp_name);
     if (PyType_Ready(&AtomicDictMeta_Type) < 0)
         return NULL;
-    assert(AtomicDictBlock_Type.tp_name);
     if (PyType_Ready(&AtomicDictBlock_Type) < 0)
         return NULL;
-    assert(AtomicDictAccessorStorage_Type.tp_name);
     if (PyType_Ready(&AtomicDictAccessorStorage_Type) < 0)
         return NULL;
-    assert(AtomicDictFastIterator_Type.tp_name);
     if (PyType_Ready(&AtomicDictFastIterator_Type) < 0)
         return NULL;
-    assert(AtomicEvent_Type.tp_name);
     if (PyType_Ready(&AtomicEvent_Type) < 0)
         return NULL;
-    assert(AtomicRef_Type.tp_name);
     if (PyType_Ready(&AtomicRef_Type) < 0)
         return NULL;
-    assert(AtomicInt_Type.tp_name);
     if (PyType_Ready(&AtomicInt_Type) < 0)
         return NULL;
-    assert(AtomicIntHandle_Type.tp_name);
     if (PyType_Ready(&AtomicIntHandle_Type) < 0)
         return NULL;
 
@@ -436,6 +426,27 @@ PyInit__cereggii(void)
         Py_DECREF(&AtomicIntHandle_Type);
         goto fail;
     }
+
+    assert(CereggiiConstant_Type.tp_name);
+
+    assert(AtomicDict_Type.tp_name);
+
+    assert(AtomicDictMeta_Type.tp_name);
+
+    assert(AtomicDictBlock_Type.tp_name);
+
+    assert(AtomicDictAccessorStorage_Type.tp_name);
+
+    assert(AtomicDictFastIterator_Type.tp_name);
+
+    assert(AtomicEvent_Type.tp_name);
+
+    assert(AtomicRef_Type.tp_name);
+
+    assert(AtomicInt_Type.tp_name);
+
+    assert(AtomicIntHandle_Type.tp_name);
+
 
     return m;
     fail:

--- a/src/include/_internal_py_core.h
+++ b/src/include/_internal_py_core.h
@@ -32,9 +32,9 @@ _Py_TryIncrefFast(PyObject *op) {
     if (_Py_IsOwnedByCurrentThread(op)) {
         _Py_INCREF_STAT_INC();
         _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
-#ifdef Py_REF_DEBUG
-        _Py_IncRefTotal(_PyThreadState_GET());
-#endif
+//#ifdef Py_REF_DEBUG
+//        _Py_IncRefTotal(_PyThreadState_GET());
+//#endif
         return 1;
     }
     return 0;
@@ -55,9 +55,9 @@ _Py_TryIncRefShared(PyObject *op)
                 &op->ob_ref_shared,
                 &shared,
                 shared + (1 << _Py_REF_SHARED_SHIFT))) {
-#ifdef Py_REF_DEBUG
-            _Py_IncRefTotal(_PyThreadState_GET());
-#endif
+//#ifdef Py_REF_DEBUG
+//            _Py_IncRefTotal(_PyThreadState_GET());
+//#endif
             _Py_INCREF_STAT_INC();
             return 1;
         }
@@ -121,9 +121,9 @@ _Py_NewRefWithLock(PyObject *op)
     if (_Py_TryIncrefFast(op)) {
         return op;
     }
-#ifdef Py_REF_DEBUG
-    _Py_IncRefTotal(_PyThreadState_GET());
-#endif
+//#ifdef Py_REF_DEBUG
+//    _Py_IncRefTotal(_PyThreadState_GET());
+//#endif
     _Py_INCREF_STAT_INC();
     for (;;) {
         Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
@@ -167,6 +167,12 @@ _PyObject_SetMaybeWeakref(PyObject *op)
         }
     }
 }
+
+#else
+
+static inline void
+_PyObject_SetMaybeWeakref(PyObject *op) {}
+
 
 #endif
 

--- a/src/include/_internal_py_core.h
+++ b/src/include/_internal_py_core.h
@@ -1,5 +1,6 @@
 #include "Python.h"
 
+#ifdef Py_GIL_DISABLED
 
 // The shared reference count uses the two least-significant bits to store
 // flags. The remaining bits are used to store the reference count.
@@ -166,6 +167,8 @@ _PyObject_SetMaybeWeakref(PyObject *op)
         }
     }
 }
+
+#endif
 
 /* Tries to incref op and returns 1 if successful or 0 otherwise. */
 static inline int

--- a/src/include/_internal_py_core.h
+++ b/src/include/_internal_py_core.h
@@ -1,0 +1,183 @@
+#include "Python.h"
+
+
+// The shared reference count uses the two least-significant bits to store
+// flags. The remaining bits are used to store the reference count.
+#define _Py_REF_SHARED_SHIFT        2
+#define _Py_REF_SHARED_FLAG_MASK    0x3
+
+// The shared flags are initialized to zero.
+#define _Py_REF_SHARED_INIT         0x0
+#define _Py_REF_MAYBE_WEAKREF       0x1
+#define _Py_REF_QUEUED              0x2
+#define _Py_REF_MERGED              0x3
+
+
+/* Tries to increment an object's reference count
+ *
+ * This is a specialized version of _Py_TryIncref that only succeeds if the
+ * object is immortal or local to this thread. It does not handle the case
+ * where the  reference count modification requires an atomic operation. This
+ * allows call sites to specialize for the immortal/local case.
+ */
+static inline int
+_Py_TryIncrefFast(PyObject *op) {
+    uint32_t local = _Py_atomic_load_uint32_relaxed(&op->ob_ref_local);
+    local += 1;
+    if (local == 0) {
+        // immortal
+        return 1;
+    }
+    if (_Py_IsOwnedByCurrentThread(op)) {
+        _Py_INCREF_STAT_INC();
+        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
+#ifdef Py_REF_DEBUG
+        _Py_IncRefTotal(_PyThreadState_GET());
+#endif
+        return 1;
+    }
+    return 0;
+}
+
+static inline int
+_Py_TryIncRefShared(PyObject *op)
+{
+    Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+    for (;;) {
+        // If the shared refcount is zero and the object is either merged
+        // or may not have weak references, then we cannot incref it.
+        if (shared == 0 || shared == _Py_REF_MERGED) {
+            return 0;
+        }
+
+        if (_Py_atomic_compare_exchange_ssize(
+                &op->ob_ref_shared,
+                &shared,
+                shared + (1 << _Py_REF_SHARED_SHIFT))) {
+#ifdef Py_REF_DEBUG
+            _Py_IncRefTotal(_PyThreadState_GET());
+#endif
+            _Py_INCREF_STAT_INC();
+            return 1;
+        }
+    }
+}
+
+/* Tries to incref the object op and ensures that *src still points to it. */
+static inline int
+_Py_TryIncrefCompare(PyObject **src, PyObject *op)
+{
+    if (_Py_TryIncrefFast(op)) {
+        return 1;
+    }
+    if (!_Py_TryIncRefShared(op)) {
+        return 0;
+    }
+    if (op != _Py_atomic_load_ptr(src)) {
+        Py_DECREF(op);
+        return 0;
+    }
+    return 1;
+}
+
+/* Loads and increfs an object from ptr, which may contain a NULL value.
+   Safe with concurrent (atomic) updates to ptr.
+   NOTE: The writer must set maybe-weakref on the stored object! */
+static inline PyObject *
+_Py_XGetRef(PyObject **ptr)
+{
+    for (;;) {
+        PyObject *value = _Py_atomic_load_ptr(ptr);
+        if (value == NULL) {
+            return value;
+        }
+        if (_Py_TryIncrefCompare(ptr, value)) {
+            return value;
+        }
+    }
+}
+
+/* Attempts to loads and increfs an object from ptr. Returns NULL
+   on failure, which may be due to a NULL value or a concurrent update. */
+static inline PyObject *
+_Py_TryXGetRef(PyObject **ptr)
+{
+    PyObject *value = _Py_atomic_load_ptr(ptr);
+    if (value == NULL) {
+        return value;
+    }
+    if (_Py_TryIncrefCompare(ptr, value)) {
+        return value;
+    }
+    return NULL;
+}
+
+/* Like Py_NewRef but also optimistically sets _Py_REF_MAYBE_WEAKREF
+   on objects owned by a different thread. */
+static inline PyObject *
+_Py_NewRefWithLock(PyObject *op)
+{
+    if (_Py_TryIncrefFast(op)) {
+        return op;
+    }
+#ifdef Py_REF_DEBUG
+    _Py_IncRefTotal(_PyThreadState_GET());
+#endif
+    _Py_INCREF_STAT_INC();
+    for (;;) {
+        Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+        Py_ssize_t new_shared = shared + (1 << _Py_REF_SHARED_SHIFT);
+        if ((shared & _Py_REF_SHARED_FLAG_MASK) == 0) {
+            new_shared |= _Py_REF_MAYBE_WEAKREF;
+        }
+        if (_Py_atomic_compare_exchange_ssize(
+                &op->ob_ref_shared,
+                &shared,
+                new_shared)) {
+            return op;
+        }
+    }
+}
+
+static inline PyObject *
+_Py_XNewRefWithLock(PyObject *obj)
+{
+    if (obj == NULL) {
+        return NULL;
+    }
+    return _Py_NewRefWithLock(obj);
+}
+
+static inline void
+_PyObject_SetMaybeWeakref(PyObject *op)
+{
+    if (_Py_IsImmortal(op)) {
+        return;
+    }
+    for (;;) {
+        Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);
+        if ((shared & _Py_REF_SHARED_FLAG_MASK) != 0) {
+            // Nothing to do if it's in WEAKREFS, QUEUED, or MERGED states.
+            return;
+        }
+        if (_Py_atomic_compare_exchange_ssize(
+                &op->ob_ref_shared, &shared, shared | _Py_REF_MAYBE_WEAKREF)) {
+            return;
+        }
+    }
+}
+
+/* Tries to incref op and returns 1 if successful or 0 otherwise. */
+static inline int
+_Py_TryIncref(PyObject *op)
+{
+#ifdef Py_GIL_DISABLED
+    return _Py_TryIncrefFast(op) || _Py_TryIncRefShared(op);
+#else
+    if (Py_REFCNT(op) > 0) {
+        Py_INCREF(op);
+        return 1;
+    }
+    return 0;
+#endif
+}

--- a/src/include/atomic_dict.h
+++ b/src/include/atomic_dict.h
@@ -8,7 +8,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include <Python.h>
-#include <structmember.h>
+//#include <structmember.h>
 #include "atomic_ref.h"
 
 

--- a/src/include/atomic_dict.h
+++ b/src/include/atomic_dict.h
@@ -30,6 +30,8 @@ typedef struct AtomicDict {
     PyObject *accessors; // PyListObject
 } AtomicDict;
 
+extern PyTypeObject AtomicDict_Type;
+
 struct AtomicDict_FastIterator;
 typedef struct AtomicDict_FastIterator AtomicDict_FastIterator;
 
@@ -75,6 +77,8 @@ PyObject *AtomicDict_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 int AtomicDict_init(AtomicDict *self, PyObject *args, PyObject *kwargs);
 
 int AtomicDict_traverse(AtomicDict *self, visitproc visit, void *arg);
+
+int AtomicDict_clear(AtomicDict *self);
 
 void AtomicDict_dealloc(AtomicDict *self);
 

--- a/src/include/atomic_dict_internal.h
+++ b/src/include/atomic_dict_internal.h
@@ -55,6 +55,8 @@ typedef struct AtomicDict_Block {
 
 extern PyTypeObject AtomicDictBlock_Type;
 
+int AtomicDictBlock_traverse(AtomicDict_Block *self, visitproc visit, void *arg);
+
 void AtomicDictBlock_dealloc(AtomicDict_Block *self);
 
 
@@ -111,6 +113,8 @@ struct AtomicDict_Meta {
     AtomicEvent *node_migration_done;
     AtomicEvent *migration_done;
 };
+
+int AtomicDictMeta_traverse(AtomicDict_Meta *self, visitproc visit, void *arg);
 
 void AtomicDictMeta_dealloc(AtomicDict_Meta *self);
 

--- a/src/include/atomic_dict_internal.h
+++ b/src/include/atomic_dict_internal.h
@@ -80,7 +80,7 @@ struct AtomicDict_Meta {
     uint8_t log_size;  // = node index_size
     uint64_t size;
 
-    PyObject *generation;
+    void *generation;
 
     uint64_t *index;
 

--- a/src/include/atomic_dict_internal.h
+++ b/src/include/atomic_dict_internal.h
@@ -40,18 +40,6 @@ typedef struct AtomicDict_Node {
 } AtomicDict_Node;
 
 
-typedef struct {
-    PyObject_HEAD
-} AtomicDict_Gen;
-
-static PyTypeObject AtomicDictGen = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_basicsize = sizeof(AtomicDict_Gen),
-    .tp_itemsize = 0,
-    .tp_new = PyType_GenericNew,
-};
-
-
 /// blocks
 #define ATOMIC_DICT_LOG_ENTRIES_IN_BLOCK 6
 #define ATOMIC_DICT_ENTRIES_IN_BLOCK (1 << ATOMIC_DICT_LOG_ENTRIES_IN_BLOCK)

--- a/src/include/atomic_dict_internal.h
+++ b/src/include/atomic_dict_internal.h
@@ -57,6 +57,8 @@ extern PyTypeObject AtomicDictBlock_Type;
 
 int AtomicDictBlock_traverse(AtomicDict_Block *self, visitproc visit, void *arg);
 
+int AtomicDictBlock_clear(AtomicDict_Block *self);
+
 void AtomicDictBlock_dealloc(AtomicDict_Block *self);
 
 
@@ -115,6 +117,8 @@ struct AtomicDict_Meta {
 };
 
 int AtomicDictMeta_traverse(AtomicDict_Meta *self, visitproc visit, void *arg);
+
+int AtomicDictMeta_clear(AtomicDict_Meta *self);
 
 void AtomicDictMeta_dealloc(AtomicDict_Meta *self);
 

--- a/src/include/atomic_dict_internal.h
+++ b/src/include/atomic_dict_internal.h
@@ -47,7 +47,7 @@ typedef struct AtomicDict_Node {
 typedef struct AtomicDict_Block {
     PyObject_HEAD
 
-    PyObject *generation;
+    void *generation;
     // PyObject *iteration;
 
     AtomicDict_Entry entries[ATOMIC_DICT_ENTRIES_IN_BLOCK];

--- a/src/include/atomic_int.h
+++ b/src/include/atomic_int.h
@@ -337,8 +337,6 @@ PyObject *AtomicIntHandle_Real_Set(AtomicIntHandle *self, PyObject *value, void 
 
 PyObject *AtomicInt_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
 
-PyObject *AtomicIntHandle_new(PyTypeObject *type, PyObject *args, PyObject *kwargs);
-
 int AtomicInt_init(AtomicInt *self, PyObject *args, PyObject *kwargs);
 
 int AtomicIntHandle_init(AtomicIntHandle *self, PyObject *args, PyObject *kwargs);

--- a/src/include/atomic_ref.h
+++ b/src/include/atomic_ref.h
@@ -31,9 +31,11 @@ PyObject *AtomicRef_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 
 int AtomicRef_init(AtomicRef *self, PyObject *args, PyObject *kwargs);
 
-void AtomicRef_dealloc(AtomicRef *self);
-
 int AtomicRef_traverse(AtomicRef *self, visitproc visit, void *arg);
+
+int AtomicRef_clear(AtomicRef *self);
+
+void AtomicRef_dealloc(AtomicRef *self);
 
 extern PyTypeObject AtomicRef_Type;
 

--- a/src/include/thread_id.h
+++ b/src/include/thread_id.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2023-present dpdani <git@danieleparmeggiani.me>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef CEREGGII_THREAD_ID_H
+#define CEREGGII_THREAD_ID_H
+
+#include "Python.h"
+
+#ifndef Py_GIL_DISABLED
+#define _Py_ThreadId PyThreadState_GET
+#endif
+
+#endif //CEREGGII_THREAD_ID_H

--- a/src/include/thread_id.h
+++ b/src/include/thread_id.h
@@ -8,7 +8,7 @@
 #include "Python.h"
 
 #ifndef Py_GIL_DISABLED
-#define _Py_ThreadId PyThreadState_GET
+#define _Py_ThreadId (uintptr_t) PyThreadState_GET
 #endif
 
 #endif //CEREGGII_THREAD_ID_H

--- a/tests/test_atomic_dict.py
+++ b/tests/test_atomic_dict.py
@@ -414,6 +414,7 @@ def test_delete_concurrent(reraise):
     assert key_error_1 or key_error_2
 
 
+@pytest.mark.skip
 def test_memory_leak():
     import tracemalloc
 

--- a/tests/test_atomic_dict.py
+++ b/tests/test_atomic_dict.py
@@ -415,7 +415,6 @@ def test_delete_concurrent(reraise):
     assert key_error_1 or key_error_2
 
 
-@pytest.mark.skip
 def test_memory_leak():
     import tracemalloc
 

--- a/tests/test_atomic_dict.py
+++ b/tests/test_atomic_dict.py
@@ -49,7 +49,7 @@ def test_weird_init():
 def test_debug():
     d = AtomicDict({"key": "value"}, min_size=64, iterable={1: 0})
     dbg = d.debug()
-    assert type(dbg) is dict  # noqa: E721
+    assert type(dbg) is dict
     assert "meta" in dbg
     assert "index" in dbg
     assert "blocks" in dbg

--- a/tests/test_atomic_dict.py
+++ b/tests/test_atomic_dict.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-present dpdani <git@danieleparmeggiani.me>
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import gc
 import random
 import threading

--- a/tests/test_atomic_int.py
+++ b/tests/test_atomic_int.py
@@ -5,7 +5,6 @@
 import gc
 import threading
 from fractions import Fraction
-from typing import Union
 
 import cereggii
 from cereggii import AtomicInt

--- a/tests/test_atomic_int.py
+++ b/tests/test_atomic_int.py
@@ -31,7 +31,7 @@ def test_set():
 
 class Result:
     def __init__(self):
-        self.result: Union[int, object, None] = 0
+        self.result: int | object | None = 0
 
 
 def test_cas():

--- a/tests/test_atomic_ref.py
+++ b/tests/test_atomic_ref.py
@@ -55,6 +55,25 @@ def test_cas():
     assert id(obj_0) == id_0 and id(obj_1) == id_1
 
 
+def test_counter():
+    r = AtomicRef(0)
+
+    def thread():
+        for _ in range(1_000):
+            expected = r.get()
+            while not r.compare_and_set(expected, expected + 1):
+                expected = r.get()
+
+    t0 = threading.Thread(target=thread)
+    t1 = threading.Thread(target=thread)
+    t0.start()
+    t1.start()
+    t0.join()
+    t1.join()
+
+    assert r.get() == 2_000
+
+
 def test_swap():
     r = AtomicRef()
     result_0 = Result()

--- a/tests/test_atomic_ref.py
+++ b/tests/test_atomic_ref.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import gc
 import threading
-from typing import Union
 
 from cereggii import AtomicRef
 

--- a/tests/test_atomic_ref.py
+++ b/tests/test_atomic_ref.py
@@ -29,7 +29,7 @@ def test_set():
 
 class Result:
     def __init__(self):
-        self.result: Union[int, object, None] = 0
+        self.result: int | object | None = 0
 
 
 def test_cas():

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -3,12 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-def test_nogil():
-    import sys
-
-    assert not sys._is_gil_enabled()
-
-
 def test_import():
     import cereggii
 


### PR DESCRIPTION
With the first RC being released, it is possible to start work on supporting CPython 3.13.

We want to support both the free-threaded and default builds.