### PR TITLE
Fix `AtomicInt64()` reflected binary operations causing segmentation faults

### DIFF
--- a/src/cereggii/atomic_int.c
+++ b/src/cereggii/atomic_int.c
@@ -587,7 +587,7 @@ AtomicInt64_Hash(AtomicInt64 *self)
         PyObject *current = NULL; \
 \
         if (PyObject_IsInstance(other, (PyObject *) &AtomicInt64_Type)) { \
-            /* this is a reflected binary operation => atomic int is in the right operand */ \
+            /* this is a reflected binary operation => atomic int is in the second argument */ \
             other = AtomicInt64_Get_callable((AtomicInt64 *) other); \
             current = (PyObject *) self; \
         } \
@@ -615,7 +615,7 @@ AtomicInt64_Power(AtomicInt64 *self, PyObject *other, PyObject *mod)
     PyObject *current = NULL;
 
     if (PyObject_IsInstance(other, (PyObject *) &AtomicInt64_Type)) {
-        /* this is a reflected binary operation => atomic int is in the right operand */
+        /* this is a reflected binary operation => atomic int is in the second argument */
         other = AtomicInt64_Get_callable((AtomicInt64 *) other);
         current = (PyObject *) self;
     }
@@ -1088,7 +1088,7 @@ AtomicInt64_MatrixMultiply(AtomicInt64 *self, PyObject *other)
     // bonus: raise the same exception as `int(...) @ other`
 
     if (PyObject_IsInstance(other, (PyObject *) &AtomicInt64_Type)) {
-        /* this is a reflected binary operation => atomic int is in the right operand */
+        /* this is a reflected binary operation => atomic int is in the second argument */
         other = (PyObject *) self;
     }
 

--- a/tests/test_atomic_int.py
+++ b/tests/test_atomic_int.py
@@ -478,4 +478,5 @@ def test_reflected_bin_ops():
 
 
 def test_issue_76():
+    # see https://github.com/dpdani/cereggii/issues/76
     assert AtomicInt64() + AtomicInt64() == 0


### PR DESCRIPTION
Fixes #69 and #76