### PR TITLE
Fix `AtomicDict` double-DECREF of a key when a colliding `__eq__` raises

### DIFF
--- a/src/cereggii/atomic_dict/insert.c
+++ b/src/cereggii/atomic_dict/insert.c
@@ -260,7 +260,7 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
     int must_grow;
     PyObject *result = expected_insert_or_update(meta, key, hash, expected, desired, &entry_loc, &must_grow, 0);
 
-    if (result != NOT_FOUND && entry_loc.location != 0) {  // it was an update
+    if (result != NOT_FOUND && entry_loc.location != 0) {  // it was an update (or a post-reserve error)
         // keep entry_loc.entry->flags reserved, or set to 0
         uint8_t flags = atomic_load_explicit((_Atomic (uint8_t) *) &entry_loc.entry->flags, memory_order_acquire);
         atomic_store_explicit((_Atomic (uint8_t) *) &entry_loc.entry->flags, flags & ENTRY_FLAGS_RESERVED, memory_order_release);
@@ -281,8 +281,17 @@ AtomicDict_CompareAndSet(AtomicDict *self, PyObject *key, PyObject *expected, Py
     }
     PyMutex_Unlock(&storage->self_mutex);
 
-    if (result == NULL && !must_grow)
-        goto fail;
+    if (result == NULL && !must_grow) {
+        // Error after (possibly) reserving an entry, e.g. a key's __eq__ raised during a
+        // collision compare. If an entry was reserved (entry_loc.location != 0), the cleanup
+        // block above already released `key`; releasing it again at `fail:` was an over-decref
+        // that corrupts the key's refcount (crashes the GC / _Py_NegativeRefcount). Release
+        // only what is still owned here.
+        Py_DECREF(desired);
+        if (entry_loc.location == 0)
+            Py_DECREF(key);
+        return NULL;
+    }
 
     int max_fill_ratio_approx_reached = 0;
     if (inserted_increased_significantly) {

--- a/tests/test_atomic_dict.py
+++ b/tests/test_atomic_dict.py
@@ -157,6 +157,36 @@ def test_setitem_updates_an_inserted_value():
     assert d[0] == 2
 
 
+def test_setitem_key_eq_raises_during_collision_no_over_decref():
+    # AtomicDict_CompareAndSet DECREF'd a colliding key twice on the error path
+    # (once in the reserved-entry cleanup, once again at `fail:`). That
+    # over-decref frees a still-referenced key -> use-after-free / GC
+    # "refcount is too small" abort. The store must raise __eq__'s exception
+    # and leave the key's refcount intact.
+    class EqRaises:
+        def __hash__(self):
+            return 101  # constant hash -> forces collisions -> __eq__ is called
+
+        def __eq__(self, other):
+            raise KeyError("boom")
+
+    d = AtomicDict()
+    d[EqRaises()] = 0  # seed one key at hash 101 (no collision yet -> inserts fine)
+
+    survivors = []
+    for _ in range(200):
+        k = EqRaises()  # collides at hash 101 -> compare calls __eq__ -> raises
+        with raises(KeyError):
+            d[k] = 1
+        survivors.append(k)  # keep every colliding key alive
+
+    # An over-decref would have freed some of these while we still hold them:
+    # touching a freed key (or the shutdown GC) would crash on the buggy build.
+    for k in survivors:
+        assert k.__hash__() == 101
+    gc_collect_until_stable()
+
+
 def test_full_dict():
     d = AtomicDict({k: None for k in range(63)})
     assert len(d._debug()["index"]) == 128


### PR DESCRIPTION

`AtomicDict_CompareAndSet` increfs the key once (`_Py_SetWeakrefAndIncref(key)`), but on the "a collision compare raised" path it releases it **twice**:

```c
_Py_SetWeakrefAndIncref(key);                          // +1
...
PyObject *result = expected_insert_or_update(...);     // returns NULL when the Py_EQ compare raises
if (result != NOT_FOUND && entry_loc.location != 0) {  // NULL != NOT_FOUND is TRUE -> runs on ERROR too
    ...
    Py_DECREF(key);   // -1   (reserved-entry cleanup)
}
if (result == NULL && !must_grow)
    goto fail;
...
fail:
    Py_DECREF(key);   // -1 AGAIN -> over-decref by one
    Py_DECREF(desired);
    return NULL;
```

The `result != NOT_FOUND` reserved-entry cleanup block was meant for a genuine update, but it also fires for the error case (`result == NULL`), and then `fail:` decrefs the key a second time. A single collision (two equal-hash keys whose first `__eq__` raises) is enough. The over-decref frees a still-referenced key, which later aborts the GC (`validate_gc_objects`: "refcount is too small") or crashes via `_Py_NegativeRefcount` / a use-after-free. Reached by both `__setitem__` and `__getitem__`.

**Fix.** The reserved-entry cleanup must still run on the error path (it clears the reserved slot — skipping it just moves the over-decref to teardown). The defect is only the *second* release, so on a post-reserve error, release just `desired`, and release `key` only when no entry was reserved (`entry_loc.location == 0`, the plain `compare_and_set` path):

```c
    if (result == NULL && !must_grow) {
        Py_DECREF(desired);
        if (entry_loc.location == 0)   // no reserved entry -> cleanup block didn't run
            Py_DECREF(key);
        return NULL;
    }
```

Refcount accounting on the two `result == NULL && !must_grow` sub-paths:
- reserved (`location != 0`, `expected` is `ANY`/`NOT_FOUND`): the cleanup block already released `key`; the fix releases only `desired`.
- non-reserved (`location == 0`, plain `compare_and_set`): the cleanup block did not run; the fix releases both `key` and `desired`.

**Similar-code audit.** This reserved-entry-plus-`fail` release pattern is unique to `AtomicDict_CompareAndSet`; no other function has the same double-release shape.

**Testing.** Built on a debug free-threaded ASan CPython 3.14. Added `tests/test_atomic_dict.py::test_setitem_key_eq_raises_during_collision_no_over_decref` (stores many colliding keys whose `__eq__` raises, keeps them alive, then touches them + runs the GC); it aborts on the unfixed build and passes with the fix. Full suite green. This is the fix from the gist, verified end-to-end (reproducer + a 400-iteration insert/lookup/compare_and_set/delete stress with `__eq__`/`__hash__`-raising keys run clean; normal behavior intact).

Found by fusil in allocation-failure mode.

*Investigation, fix and PR draft by Claude Code (Opus 4.8).*
