### PR TITLE
Fix `get_handle()` crashing on allocation failure

### DIFF
--- a/src/cereggii/atomic_dict/atomic_dict.c
+++ b/src/cereggii/atomic_dict/atomic_dict.c
@@ -620,6 +620,8 @@ AtomicDict_GetHandle(AtomicDict *self)
         goto fail;
 
     args = Py_BuildValue("(O)", self);
+    if (args == NULL)
+        goto fail;
     if (ThreadHandle_init(handle, args, NULL) < 0)
         goto fail;
     Py_DECREF(args);

--- a/src/cereggii/atomic_int.c
+++ b/src/cereggii/atomic_int.c
@@ -547,6 +547,8 @@ AtomicInt64_GetHandle(AtomicInt64 *self)
     }
 
     args = Py_BuildValue("(O)", self);
+    if (args == NULL)
+        goto fail;
     if (ThreadHandle_init(handle, args, NULL) < 0)
         goto fail;
     Py_DECREF(args);

--- a/src/cereggii/atomic_ref.c
+++ b/src/cereggii/atomic_ref.c
@@ -167,6 +167,8 @@ AtomicRef_GetHandle(AtomicRef *self)
     }
 
     args = Py_BuildValue("(O)", self);
+    if (args == NULL)
+        goto fail;
     if (ThreadHandle_init(handle, args, NULL) < 0)
         goto fail;
     Py_DECREF(args);

--- a/tests/test_thread_handle.py
+++ b/tests/test_thread_handle.py
@@ -36,10 +36,7 @@ def test_reflected_bin_ops():
 
 
 def test_get_handle_survives_allocation_failure():
-    # get_handle() built its args tuple for ThreadHandle_init without a NULL
-    # check, so an allocation failure (Py_BuildValue -> NULL) reached
-    # PyArg_ParseTuple(NULL): SIGABRT on a debug build, SIGSEGV on release.
-    # It must raise MemoryError instead of crashing.
+    # See https://github.com/dpdani/cereggii/pull/147/
     _testcapi = pytest.importorskip("_testcapi")
     if not hasattr(_testcapi, "set_nomemory"):
         pytest.skip("_testcapi.set_nomemory unavailable")

--- a/tests/test_thread_handle.py
+++ b/tests/test_thread_handle.py
@@ -1,3 +1,4 @@
+import pytest
 from cereggii import AtomicDict, AtomicInt64, AtomicRef, ThreadHandle
 from pytest import raises
 
@@ -32,3 +33,30 @@ def test_reflected_bin_ops():
     assert 2 - ThreadHandle(1) == 1
     assert 2 / ThreadHandle(1) == 2
     assert 3 ^ ThreadHandle(1) == 2
+
+
+def test_get_handle_survives_allocation_failure():
+    # get_handle() built its args tuple for ThreadHandle_init without a NULL
+    # check, so an allocation failure (Py_BuildValue -> NULL) reached
+    # PyArg_ParseTuple(NULL): SIGABRT on a debug build, SIGSEGV on release.
+    # It must raise MemoryError instead of crashing.
+    _testcapi = pytest.importorskip("_testcapi")
+    if not hasattr(_testcapi, "set_nomemory"):
+        pytest.skip("_testcapi.set_nomemory unavailable")
+
+    # Drain the 1-element tuple free-list so Py_BuildValue("(O)") actually
+    # allocates (otherwise it reuses a cached tuple and never hits the failure).
+    hold = [(i,) for i in range(5000)]
+
+    for factory in (AtomicRef, AtomicDict, AtomicInt64):
+        for start in range(40):
+            obj = factory()
+            _testcapi.set_nomemory(start, start + 2)
+            try:
+                obj.get_handle()
+            except MemoryError:
+                pass
+            finally:
+                _testcapi.remove_mem_hooks()
+
+    assert len(hold) == 5000  # keep the free-list drain alive to here


### PR DESCRIPTION

`AtomicRef.get_handle()`, `AtomicDict.get_handle()` and `AtomicInt64.get_handle()` build the argument tuple for `ThreadHandle_init` with `Py_BuildValue("(O)", self)` and pass it on without a NULL check:

```c
handle = (ThreadHandle *) ThreadHandle_new(&ThreadHandle_Type, NULL, NULL);
if (handle == NULL) { ... }
args = Py_BuildValue("(O)", self);            // returns NULL if the allocation fails
if (ThreadHandle_init(handle, args, NULL) < 0)  // args used with no NULL check
    goto fail;
```

Under memory pressure `Py_BuildValue` returns NULL, and `ThreadHandle_init` then calls `PyArg_ParseTuple(NULL, "O", ...)`, which trips CPython's `assert(args != NULL)` (SIGABRT on a debug build) or dereferences NULL (SIGSEGV on release). The sibling `ThreadHandle_new` allocation right above is already checked; only the `Py_BuildValue` isn't.

**Fix:** check the tuple and jump to the existing cleanup on failure, at all three sites. `get_handle()` now raises `MemoryError` instead of crashing.

**Similar-code audit.** I grepped every `Py_BuildValue` in `src/`. The only ones that hand their result to a function that dereferences it without a check are these three `get_handle` sites (all fixed here). The rest either return the result straight to Python (NULL propagates as a normal error) or pass it to another `Py_BuildValue` with `O`, which itself NULL-checks.

**Testing.** Built on a debug free-threaded ASan CPython 3.14. Added `tests/test_thread_handle.py::test_get_handle_survives_allocation_failure`, which uses `_testcapi.set_nomemory` (skipped if unavailable) to fail a sliding window of allocations across `AtomicRef`/`AtomicDict`/`AtomicInt64`; it aborts the process on the unfixed build and passes with the fix. Full suite green.

Found by fusil in allocation-failure mode.

*Investigation, fix and PR draft by Claude Code (Opus 4.8).*
