### PR TITLE
Fix cyclic-GC double-counting of pages shared across a resize

### DIFF
--- a/src/cereggii/atomic_dict/meta.c
+++ b/src/cereggii/atomic_dict/meta.c
@@ -130,7 +130,12 @@ AtomicDictMeta_traverse(AtomicDictMeta *self, visitproc visit, void *arg)
 
     int64_t greatest_allocated_page = atomic_load_explicit((_Atomic (int64_t) *) &self->greatest_allocated_page, memory_order_acquire);
     for (int64_t page_i = 0; page_i <= greatest_allocated_page; ++page_i) {
-        AtomicDictPage_traverse(self->pages[page_i], visit, arg);
+        // Visit the page as a GC node rather than recursing into it here: pages
+        // are shared between the old and new meta across a resize, so recursing
+        // would report each shared page's keys/values once per meta and
+        // double-count them in the cyclic GC (crashing the debug GC's
+        // validate_gc_objects). As a tracked object each page is traversed once.
+        Py_VISIT(self->pages[page_i]);
     }
     return 0;
 }

--- a/src/cereggii/atomic_dict/pages.c
+++ b/src/cereggii/atomic_dict/pages.c
@@ -13,7 +13,7 @@ AtomicDictPage *
 AtomicDictPage_New(void)
 {
     AtomicDictPage *new = NULL;
-    new = PyObject_New(AtomicDictPage, &AtomicDictPage_Type);
+    new = PyObject_GC_New(AtomicDictPage, &AtomicDictPage_Type);
 
     if (new == NULL)
         return NULL;
@@ -22,6 +22,7 @@ AtomicDictPage_New(void)
     memset(new->entries, 0, sizeof(AtomicDictPaddedEntry) * ATOMIC_DICT_ENTRIES_IN_PAGE);
     cereggii_tsan_ignore_writes_end();
 
+    PyObject_GC_Track(new);
     return new;
 }
 
@@ -63,6 +64,7 @@ AtomicDictPage_clear(AtomicDictPage *self)
 void
 AtomicDictPage_dealloc(AtomicDictPage *self)
 {
+    PyObject_GC_UnTrack(self);
     AtomicDictPage_clear(self);
     Py_TYPE(self)->tp_free((PyObject *) self);
 }

--- a/src/cereggii/cereggii.c
+++ b/src/cereggii/cereggii.c
@@ -203,8 +203,9 @@ PyTypeObject AtomicDictPage_Type = {
     .tp_name = "cereggii._AtomicDictPage",
     .tp_basicsize = sizeof(AtomicDictPage),
     .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = PyType_GenericNew,
+    .tp_traverse = (traverseproc) AtomicDictPage_traverse,
     .tp_clear = (inquiry) AtomicDictPage_clear,
     .tp_dealloc = (destructor) AtomicDictPage_dealloc,
 };

--- a/tests/test_atomic_dict.py
+++ b/tests/test_atomic_dict.py
@@ -206,6 +206,32 @@ def test_concurrent_insert():
     assert d[2] in (1, 2)
 
 
+def test_concurrent_store_forcing_resize_gc_safe():
+    # Pages are shared between the old and new meta across a resize; the meta's
+    # traverse recursed into them inline, so a shared page's keys/values were
+    # visited once per meta and double-counted by the cyclic GC -> the debug GC
+    # aborted (validate_gc_objects: "refcount is too small"). Enough concurrent
+    # inserters fill a page and force the resize; a deferred-refcount key (a
+    # function) makes the miscount fatal. The GC must stay consistent.
+    def deferred_key():  # functions use deferred reference counting
+        pass
+
+    d = AtomicDict()
+    n = 8  # 8 x reservation_buffer_size fills a page -> forces a resize
+    barrier = threading.Barrier(n)
+
+    @TestingThreadSet.repeat(n)
+    def storers():
+        barrier.wait()
+        for _ in range(3000):
+            d[deferred_key] = 1
+
+    storers.start_and_join()
+
+    assert d[deferred_key] == 1
+    gc_collect_until_stable()  # aborted here on the buggy build
+
+
 def test_get_default():
     d = AtomicDict()
     d["key"] = "value"


### PR DESCRIPTION

This is the real fix for gist bug #2 ("concurrent stores of a deferred-refcount key corrupt the key's refcount"). rr showed the refcount is *not* corrupted — the bug is a **cyclic-GC double-count of shared pages**.

## Root cause

`AtomicDictPage` is a `PyObject` but is created with `PyObject_New` (not GC-tracked), and `AtomicDictMeta_traverse` walks its pages by calling `AtomicDictPage_traverse(self->pages[i], ...)` **inline** — i.e. the meta reports its pages' keys/values to the cyclic GC directly.

On a resize, `meta_copy_pages` **shares the page objects** between the old and new meta (both hold a reference; the pages are copied by pointer). A stale per-accessor `storage->meta` (e.g. an exited worker's accessor storage, still in `self->accessors` and visited by `AtomicDict_traverse`) keeps the **old meta alive**. So the same page object is reachable from two live metas, and each meta's traverse reports that page's keys — the GC subtracts one internal reference **per meta** for a key that the page references only **once**.

`update_refs` then computes `gc_refs = Py_REFCNT − internal_refs` as negative, and the debug GC aborts:

```
Python/gc_free_threading.c: validate_gc_objects:
    Assertion "gc_get_refs(op) >= 0" failed: refcount is too small
  object type name: function
```

It needs enough concurrent inserters to fill a page and force a resize (8 threads reproduce; 2 don't — 8 × `reservation_buffer_size` = a full page). It is fatal specifically with **deferred-refcount keys** (functions/types/modules): their `gc_refs` seed is `Py_REFCNT − _Py_REF_DEFERRED`, which is small, so one extra subtraction crosses zero. On a release build the assertion is compiled out and no crash was observed under heavy stress, but the miscount is real.

### How I pinned it (rr)

Reverse-watching the key's `ob_tid` (which the GC repurposes as `gc_refs`) from the assertion showed the decrements come from **two different meta objects** (`AtomicDictMeta_traverse` at two addresses) both traversing the **same page object** — the smoking gun. (An earlier reverse-watch on `ob_ref_local` proved the refcount itself is correct, which is what redirected the diagnosis away from refcounting.)

## Fix

Make each page a first-class GC node so a shared page is traversed **once** by the collector regardless of how many metas reference it:

- `AtomicDictPage_Type`: add `Py_TPFLAGS_HAVE_GC` and `tp_traverse = AtomicDictPage_traverse`.
- `AtomicDictPage_New`: `PyObject_GC_New` + `PyObject_GC_Track`.
- `AtomicDictPage_dealloc`: `PyObject_GC_UnTrack` first.
- `AtomicDictMeta_traverse`: `Py_VISIT(self->pages[i])` instead of recursing.

11 lines of source. Works for all key types, and doesn't touch reference counting or vendor any CPython internals.

## Testing

Built on a debug free-threaded ASan CPython 3.14.
- New regression test `test_concurrent_store_forcing_resize_gc_safe` (8 threads storing a function key, forcing a resize, then `gc_collect_until_stable()`): aborts on the unfixed build, passes with the fix.
- Original reproducer: 0/15 (was 5/5). 40-round soak with function + type keys: clean.
- Full suite green. (`test_racy_deletes` is a pre-existing flaky lock-free-read crash — ~1/20 on *pristine* main too, unrelated to this change; deselect it or treat separately.)
- ruff + black clean.

## How this replaces the gist's proposed fix

The gist proposed guarding `_Py_SetWeakrefAndIncref` for deferred objects. rr showed that was a red herring: the refcount is correct, and the guard's only real effect (keeping `ob_ref_local` stable single-threaded) fixes a benign asymmetry that already self-corrects via `_Py_MergeZeroLocalRefcount`. This GC fix is the actual root cause, so the `fix/deferred-refcount-key` draft can be dropped. (If you still want the refcount-hygiene tidy-up as a separate change, happy to, but it isn't needed for correctness.)

Found by fusil in allocation-failure mode.

*Investigation, fix and PR draft by Claude Code (Opus 4.8).*
